### PR TITLE
ci(configs): onBrokenLinks → 'throw' + migration deprecated config

### DIFF
--- a/site/docusaurus.config.ts
+++ b/site/docusaurus.config.ts
@@ -29,8 +29,13 @@ const config: Config = {
   organizationName: 'LabAixBidouille',
   projectName: 'wikilab',
 
-  onBrokenLinks: 'warn',
-  onBrokenMarkdownLinks: 'warn',
+  onBrokenLinks: 'throw',
+
+  markdown: {
+    hooks: {
+      onBrokenMarkdownLinks: 'throw',
+    },
+  },
 
   i18n: {
     defaultLocale: 'fr',


### PR DESCRIPTION
## Résumé

- Passe `onBrokenLinks: 'warn'` → `'throw'` : tout lien interne mort casse maintenant le build.
- Migre `onBrokenMarkdownLinks` (deprecated) vers la nouvelle position `markdown.hooks.onBrokenMarkdownLinks` (Docusaurus v4 ready), aussi en `'throw'`.

## Type de changement

- [ ] Contenu — fiche, doc, texte
- [ ] Catalogue — entrée(s) dans `resources.ts` ou `projects.ts`
- [ ] Code — composant React, page, type, CSS
- [x] Configuration — config Docusaurus, CI, hooks

## Test plan

- [x] `npm run build` passe sans nouveau warning ni erreur
- [x] Plus de warning de deprecation `onBrokenMarkdownLinks`
- [x] Aucun broken link détecté dans l'état actuel
- [x] La CI build.yml reste OK

## Issues liées

Refs #39 — coche le chantier 7.