### PR TITLE
ci(configs): bump GitHub Actions à v5 (Node.js 24-ready)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,11 +19,11 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: npm
@@ -49,9 +49,9 @@ jobs:
       run:
         working-directory: site
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,15 +22,15 @@ jobs:
       run:
         working-directory: site
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: npm
           cache-dependency-path: site/package-lock.json
       - run: npm ci
       - run: npm run build
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v4
         with:
           path: site/build
 
@@ -41,5 +41,5 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/deploy-pages@v4
+      - uses: actions/deploy-pages@v5
         id: deployment

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -13,7 +13,7 @@ jobs:
   check-links:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Check external links
         id: check-links


### PR DESCRIPTION
## Résumé

GitHub annonce la dépréciation de Node.js 20 dans les actions :

- 2 juin 2026 : Node.js 24 devient le default
- 16 septembre 2026 : Node.js 20 retiré

Bump des actions pour rester sur la branche supportée :

- `actions/checkout@v4` → `v5`
- `actions/setup-node@v4` → `v5`
- `actions/upload-pages-artifact@v3` → `v4`
- `actions/deploy-pages@v4` → `v5`

## Type de changement

- [x] Configuration — config Docusaurus, CI, hooks

## Test plan

- [x] Tous les workflows référencés (`build.yml`, `deploy.yml`, `links.yml`) sont mis à jour
- [x] Le warning "Node.js 20 actions are deprecated" devrait disparaître au prochain run

## Issues liées

Refs #39 — coche le chantier 12.