### PR TITLE
chore(configs): script site:clean pour nettoyer artefacts locaux

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -187,6 +187,7 @@ Mots à éviter (équivalents accentués préférés) listés dans `cspell.json`
 - **Le build échoue en local** : `rm -rf node_modules .docusaurus && npm ci && npm run site:build`
 - **Le hook pre-commit bloque inutilement** : ne **pas** utiliser `--no-verify` ; corriger le souci, ou poser la question dans une issue si la règle pose un problème.
 - **Le build échoue en CI mais marche en local** : vérifier la version Node (`node --version` doit être ≥ 20), refaire `npm ci` propre.
+- **Le build affiche `Duplicate routes found` en local** : c'est typiquement dû à des artefacts `.js` laissés par un IDE/`tsc` à côté des `.tsx` source dans `site/src/`. Lancer `npm run site:clean` à la racine pour les nettoyer (le build CI n'est pas affecté car ces fichiers ne sont pas commités).
 - **Une fiche n'apparaît pas dans le catalogue** : vérifier l'entrée dans `resources.ts` (id unique, slug correct), redémarrer `npm run site:start`.
 - **Un lien interne casse** : vérifier la sortie du build, mettre à jour les références.
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "site:start": "npm --prefix site start",
     "site:build": "npm --prefix site run build",
     "site:typecheck": "npm --prefix site run typecheck",
+    "site:clean": "rm -rf site/build site/.docusaurus site/.cache-loader && find site/src -name '*.js' -type f -delete",
     "prepare": "husky"
   },
   "devDependencies": {


### PR DESCRIPTION
## Résumé

Le build local affichait un warning `Duplicate routes found` pour 14 routes (catalogue, machines, projets/*, /). Cause : artefacts `.js` laissés à côté des `.tsx` source dans `site/src/` par un IDE ou `tsc` exécuté à un moment. Docusaurus voit les deux et signale le conflit.

Le build CI n'est **pas affecté** : les `.js` ne sont pas commités (ignorés via `.gitignore`).

## Changements

- Ajoute `npm run site:clean` qui supprime `site/build`, `site/.docusaurus`, `site/.cache-loader`, et les artefacts `*.js` dans `site/src/`
- Documente le diagnostic dans `TESTING.md` (section "En cas de problème")

## Type de changement

- [x] Configuration — config Docusaurus, CI, hooks

## Test plan

- [x] Build local passe sans warning Duplicate routes après `npm run site:clean`
- [x] Le script supprime bien les artefacts `.js` dans `site/src/`

## Issues liées

Refs #39 — coche le chantier 9.