### PR TITLE
docs: refonte documentation + extraction CONVENTIONS.md

### DIFF
--- a/.cspell/wikilab.txt
+++ b/.cspell/wikilab.txt
@@ -137,6 +137,9 @@ stager
 flagWords
 backticks
 pdfs
+precommit
+prepa
+micropython
 
 # Identifiants TypeScript en kebab-case ASCII (slugs, IDs, admonition keywords).
 # Ils restent volontairement sans accent pour être des identifiants techniques valides.
@@ -150,3 +153,8 @@ hypothese
 citoyennete
 creativite
 debranchees
+debranchee
+enquete
+intermediaire
+debutant
+avance

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,18 +1,36 @@
-# Wiki@LAB — Guide de développement
+# CLAUDE.md — instructions pour les assistants IA
+
+> Ce fichier est destiné aux **assistants IA** (Claude Code, etc.) qui interviennent sur ce repo. Il décrit l'architecture du projet et renvoie vers les documents qui font autorité pour les humains.
+>
+> **Pour les contributeurs humains** :
+>
+> - Conventions de contenu et de formatage des fiches → [`CONVENTIONS.md`](CONVENTIONS.md)
+> - Workflow git, PR, CI, hooks → [`CONTRIBUTING.md`](CONTRIBUTING.md)
+> - Tests et vérifications → [`TESTING.md`](TESTING.md)
+> - Présentation du projet → [`README.md`](README.md)
 
 ## Architecture
 
-- **Framework** : Docusaurus v4 (TypeScript)
-- **Dossier site** : `site/`
-- **Config** : `site/docusaurus.config.ts`
+### Site Docusaurus (`site/`)
+
+- **Framework** : Docusaurus v4 (TypeScript, mode strict, `noEmit`)
+- **Config** : `site/docusaurus.config.ts` (`onBrokenLinks: 'throw'`, `markdown.hooks.onBrokenMarkdownLinks: 'throw'`)
 - **CSS custom** : `site/src/css/custom.css`
-- **Données catalogue** : `site/src/data/resources.ts`
+- **Données catalogue** : `site/src/data/resources.ts` (types stricts : `Discipline`, `Tool`, `Software`, `Project`, `Format`, `Category`)
 - **Données projets** : `site/src/data/projects.ts`
-- **Pages** : `site/src/pages/` (catalogue.tsx, index.tsx, projets/, machines/, about.tsx)
-- **Docs (fiches)** : `site/docs/` (lets-steam/, mimesis/, unplugged/, jeditrack/, robots-meet-arts/, steamcity/)
-- **Images** : `site/static/img/ressources/<projet>/<fiche-id>/` — un sous-dossier par fiche, avec `icone.png`/`icone.svg` + photos additionnelles. Les dossiers sont créés pour les 184 fiches (`.gitkeep` pour celles en attente d'images).
+- **Pages** : `site/src/pages/` (catalogue.tsx, index.tsx, projets/, machines.tsx, about.md)
+- **Theme custom** : `site/src/theme/Admonition/` (composants pour `:::question` et `:::hypothese`)
+- **Types globaux** : `site/src/types/css.d.ts` (extension de `React.CSSProperties` pour les CSS variables `--*`)
+- **Docs (fiches)** : `site/docs/` (un sous-dossier par projet)
+- **Images** : `site/static/img/ressources/<projet>/<fiche-id>/` — un sous-dossier par fiche (`.gitkeep` pour celles en attente)
 - **PDFs** : `site/static/pdf/<projet>/`
-- **Sources markdown brutes** : `markdown/` (fichiers originaux avant conversion)
+- **Sources markdown brutes** : `markdown/` (originaux pré-conversion)
+
+### Outillage qualité (racine)
+
+- **`package.json` racine** : Prettier, markdownlint, cspell, husky, commitlint, lint-staged, validate-branch-name, lychee
+- **Hooks Git** : `.husky/pre-commit` (validate-branch-name + git-precommit-checks + lint-staged), `.husky/commit-msg` (commitlint)
+- **CI** : `.github/workflows/build.yml` (lint + typecheck + build sur PR), `deploy.yml` (Pages), `links.yml` (cron Lychee), `auto-assign.yml`
 
 ## Projets intégrés
 
@@ -25,151 +43,48 @@
 | Robots Meet Arts | 29                    | OK        | OK          | OK                        | `#169da7` |
 | SteamCity        | 25 + 9 fiches prog    | OK        | OK          | OK                        | `#DD5350` |
 | The Dexter Lab   | 20 + 13 fiches prog   | OK        | OK (icônes) | OK (feuilles travail)     | `#1a4a48` |
-| Youth AI Lab     | 5                     | OK        | OK          | OK                        | `#b34520` |
+| Youth AI Lab     | 6                     | OK        | OK          | OK                        | `#b34520` |
 | I-Novmicro #2    | 1 (Découverte STeaMi) | OK        | -           | -                         | `#8a6e18` |
 | Projets du LAB   | 20                    | OK        | Partiels    | -                         | -         |
 
+> **Initiative en cours** : I-Novmicro #2 va recevoir 22+ fiches dans le cadre de l'intégration STeaMi/MicroPython (15 fiches portées de Let's STEAM + 7 fiches enseignants). Voir EPIC [#2](https://github.com/LabAixBidouille/wikilab/issues/2) (phase 1) et [#30](https://github.com/LabAixBidouille/wikilab/issues/30) (phase 2 — autres projets).
+
 ## Conventions de formatage des fiches
 
-### Header (en-tête)
+**→ Voir [`CONVENTIONS.md`](CONVENTIONS.md)** pour le détail complet (header, structure, callouts, images, texte, catalogue, sous-pages, fiches programmation extraites, couleurs).
 
-- Flex layout : titre + badges + tableau + matériel + PDF + callout à gauche, icône 225px à droite
-- Titre H1 avec icône SVG flat design inline (couleur du projet, opacités 0.1/0.25/1.0)
-- Badges : disciplines (primary), outils (info), logiciels (warning/secondary)
-- Tableau : colonnes égales, en-tête fond `#09246C` + texte blanc
-- Bouton PDF rose (`#e83e8c`) si PDF disponible
-- Callout `:::tip[**Ressources imprimables incluses dans le PDF.**]` avec liste si applicable
+Toute modification de ces conventions doit se faire dans `CONVENTIONS.md` (qui fait autorité), pas ici.
 
-### Structure des fiches (règles SteamCity)
+## Build et commandes locales
 
-- **Introduction** (H2) contient : texte d'intro, Structure du protocole (H3), tableau durée/matériel sans titre "Pour bien démarrer", Glossaire (H3) en liste à puces
-- **Pas de titre "## Protocole"** : les phases sont directement H2
-- **Phases** : `## Phase 1 : Compréhension...` (majuscule après `:`)
-- **Sous-sections des phases** : Conceptualisation, Investigation, Analyse en H3
-- **Fiches programmation** : extraites dans `steamcity/programmation/` avec lien dans la fiche principale
+Prérequis : Node.js 20+. Voir [`CONTRIBUTING.md`](CONTRIBUTING.md) pour l'installation complète.
 
-### Callouts
-
-- `:::tip` (vert, icône imprimante) : ressources imprimables UNIQUEMENT
-- `:::info` (bleu, icône info/ampoule) : conseils, remarques, notes techniques
-- `:::caution` (rose, icône ▶) : phases d'activité
-- `:::note` (gris) : notes diverses
-- Ne JAMAIS utiliser `:::tip` pour des conseils non-imprimables
-
-### Images
-
-- En bloc, alignées à gauche (CSS global `display: block`)
-- Après le texte descriptif qu'elles illustrent
-- Légendes UNIQUEMENT si demandé explicitement (style global déjà appliqué : italique, 0.9em, gris foncé, **centré** via `.markdown figcaption`)
-- **RÈGLE STRICTE** : dès qu'une `<figcaption>` est présente, l'image ET la légende DOIVENT être centrées. Le CSS global `.markdown figure:has(figcaption)` applique le centrage automatiquement, mais il faut quand même appliquer le pattern :
-
-  ```jsx
-  <figure style={{ margin: '1rem auto', textAlign: 'center' }}>
-    <img src="..." style={{ maxWidth: '100%', height: 'auto', margin: '0 auto' }} />
-    <figcaption style={{ margin: 0 }}>...</figcaption>
-  </figure>
-  ```
-
-  NE JAMAIS laisser une image avec figcaption alignée à gauche.
-
-- **Images côte à côte sans étirement** : flex container avec `alignItems: 'flex-start'` et chaque image en `maxWidth: 'calc(50% - 1rem)'` + `height: 'auto'` + `alignSelf: 'flex-start'` (préserve les proportions naturelles, espace vide sous la plus petite si tailles différentes — c'est OK)
-
-  ```jsx
-  <div style={{ display: 'flex', gap: '2rem', alignItems: 'flex-start', flexWrap: 'wrap' }}>
-    <img
-      src="..."
-      style={{ maxWidth: 'calc(50% - 1rem)', height: 'auto', alignSelf: 'flex-start' }}
-    />
-    <img
-      src="..."
-      style={{ maxWidth: 'calc(50% - 1rem)', height: 'auto', alignSelf: 'flex-start' }}
-    />
-  </div>
-  ```
-
-- Centrage figure + image : `<figure style={{width: 'X%', margin: '1rem auto'}}><img style={{width: '100%'}}/></figure>`
-
-### Texte
-
-- Justifié (CSS global)
-- Titres numérotés de manière homogène (Partie 1, 2, 3...)
-- Pas de bold dans les headings
-- `--` dans les titres → `:` + majuscule après (règle wiki globale)
-- Listes avec `:` → premier élément en gras : `- **Label** : description`
-- Footer Erasmus+ en bas de chaque fiche
-- Gras : "Contexte de la séquence" et "Objectifs d'apprentissage"
-
-### Contenu à supprimer
-
-- Mentions italiques de phase (Découverte et échauffement, Fin de la séquence...)
-- Blockquotes citations en début de page → texte normal
-- Doubles `---` en fin de fiche
-- Mentions "Une activité développée par..."
-- Références QR code → "disponible dans le PDF"
-- Glossaires en tableau → listes à puces
-
-### Notes enseignants
-
-- Format : `:::info[Notes pour l'enseignant·e]` (bleu, pas gris)
-- Convertir tous les blockquotes `> **Notes pour l'enseignant·e**` en callouts info
-
-### Catalogue (`resources.ts`)
-
-- Chaque fiche = une entrée avec id, title, slug, project, summary, disciplines, tools, software, ageMin, ageMax, durationMinutes, difficulty, formats, categories, keywords, pdf?, thumbnail?
-- `categories` : 11 approches pédagogiques (`programmation`, `exploration-scientifique`, `robotique-ludique`, `animation-jeunesse`, `citoyennete-territoire`, `ia-esprit-critique`, `sequences-debranchees`, `theatre-sciences`, `arts-creativite`, `environnement-nature`, `makers-fabrication`). Multi-catégories autorisées.
-- `thumbnail` optionnel : pointe vers `/img/ressources/<projet>/<fiche-id>/icone.png` (ou `.svg`)
-- maxDuration filtre par défaut = 240 min (attention aux fiches longues, utiliser 240 max)
-
-### Suivi photos
-
-- Page interactive : `/photos-suivi` (cases à cocher avec persistance localStorage)
-- Convention : un sous-dossier par fiche sous `site/static/img/ressources/<projet>/<fiche-id>/`
-- Le dossier de chaque fiche doit contenir `icone.png`/`icone.svg` + photos additionnelles
-- Exception : `projets-du-lab/` racine contient le dump d'images historique (référencé dans les MD), plus les sous-dossiers `lab-<id>/` pour les icônes
-
-### Sous-pages (ex: borne-arcade, programmation)
-
-- Dossier dans `docs/PROJET/SOUSPROJET/`
-- Fichier `_category_.json` avec label, position, collapsed
-- Ajouter une entrée au catalogue qui pointe vers la page d'introduction/première page
-
-### Fiches de programmation extraites
-
-- Les fiches longues (SteamCity, TheDexterLab) qui contiennent des sections de programmation doivent avoir ces sections EXTRAITES dans `docs/PROJET/programmation/`
-- **Format obligatoire** : même format que les fiches Let's STEAM (voir `docs/lets-steam/r1as01-led.md` comme référence)
-  - Flex header complet avec SVG icône couleur projet, badges (discipline, carte, logiciel), tableau Projet/Durée/Difficulté/Âge
-  - Section "## Matériel"
-  - Bouton PDF si disponible
-  - Section "## De quoi parle-t-on ?" avec intro sur le concept/hardware
-  - Section "## Objectifs d'apprentissage" en liste à puces
-  - Contenu de programmation (étapes, code, câblage)
-  - Footer Erasmus+
-- Dans la fiche principale, remplacer la section extraite par un lien `## Programmation` pointant vers la fiche technique
-- Les tableaux vides (exemples à remplir) doivent avoir des lignes de taille égale (même nombre de cellules)
-
-## Build
+Raccourcis utiles depuis la racine :
 
 ```bash
-export PATH="/home/manon/.nvm/versions/node/v20.20.2/bin:$PATH"
-cd site
-npx docusaurus build
-npx docusaurus start --port 3333
+npm run site:start       # serveur de dev
+npm run site:build       # build statique
+npm run site:typecheck   # tsc --noEmit
+npm run site:clean       # nettoie build/, .docusaurus/, et artefacts .js dans src/
 ```
 
 ## Git
 
 - Remote : `https://github.com/LabAixBidouille/wikilab.git`
-- Branche : `main`
+- Branche par défaut : `main` — **protégée**, modifications via PR uniquement
+- Conventional Commits + validate-branch-name (voir [`CONTRIBUTING.md`](CONTRIBUTING.md))
 - Auth : `gh auth login` (GitHub CLI)
-- 3 PDFs exclus (.gitignore) car >50MB : Vivre en harmonie, Potluck March, Equal
+- 3 PDFs exclus (`.gitignore`) car >50MB : Vivre en harmonie, Potluck March, Equal
 
-## TODO
+## Travaux en cours
 
-- [x] Icônes projet (icone.png) pour JediTrack et Robots Meet Arts
-- [ ] Adapter la couleur du tableau par projet (actuellement codée en dur `#09246C`)
-- [x] Tous les projets intégrés !
-- [ ] Git LFS pour les 3 PDFs Unplugged >50MB
-- [x] Photos pour les fiches JediTrack et Robots Meet Arts
-- [x] Refonte wiki SteamCity (24 fiches + 9 prog, callouts, annexes imprimables)
-- [ ] Refonte wiki similaire pour les autres projets (style hérité PDF→wiki à uniformiser)
-- [ ] Vérifier images d'illustration manquantes sur thedexterlab (20 fiches avec uniquement l'icône)
+Le suivi détaillé est sur GitHub : [issues](https://github.com/LabAixBidouille/wikilab/issues), [milestones](https://github.com/LabAixBidouille/wikilab/milestones), [project board](https://github.com/orgs/LabAixBidouille/projects/1).
+
+Chantiers ouverts notables :
+
+- Adapter la couleur du tableau header de fiche par projet (actuellement codée en dur `#09246C`)
+- Git LFS pour les 3 PDFs Unplugged >50MB
+- Refonte wiki similaire à SteamCity pour les autres projets (style hérité PDF→wiki à uniformiser)
+- Vérifier images d'illustration manquantes sur TheDexterLab (20 fiches avec uniquement l'icône)
+- **Intégration STeaMi/MicroPython** — voir EPIC [#2](https://github.com/LabAixBidouille/wikilab/issues/2) (phase 1, 22+ fiches) et [#30](https://github.com/LabAixBidouille/wikilab/issues/30) (phase 2)
+- **Dette DX** — voir [#39](https://github.com/LabAixBidouille/wikilab/issues/39) (couverture cspell sur fiches, passe Prettier sur fiches après refactor MDX)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@
 
 ### Site Docusaurus (`site/`)
 
-- **Framework** : Docusaurus v4 (TypeScript, mode strict, `noEmit`)
+- **Framework** : Docusaurus v3.10 (TypeScript, mode strict ; flag `future.v4: true` activé pour préparer la migration v4). Le tsconfig parent `@docusaurus/tsconfig` impose `noEmit: true`, donc `tsc` ne génère pas de `.js` à côté des sources.
 - **Config** : `site/docusaurus.config.ts` (`onBrokenLinks: 'throw'`, `markdown.hooks.onBrokenMarkdownLinks: 'throw'`)
 - **CSS custom** : `site/src/css/custom.css`
 - **Données catalogue** : `site/src/data/resources.ts` (types stricts : `Discipline`, `Tool`, `Software`, `Project`, `Format`, `Category`)
@@ -64,7 +64,7 @@ Raccourcis utiles depuis la racine :
 ```bash
 npm run site:start       # serveur de dev
 npm run site:build       # build statique
-npm run site:typecheck   # tsc --noEmit
+npm run site:typecheck   # tsc (noEmit hérité de @docusaurus/tsconfig)
 npm run site:clean       # nettoie build/, .docusaurus/, et artefacts .js dans src/
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Merci de l'intérêt que tu portes au projet ! Ce document décrit le workflow et les conventions pour contribuer.
 
-Pour les **conventions de formatage des fiches** (header, callouts, images, footer Erasmus+, etc.), voir [`CLAUDE.md`](CLAUDE.md) qui fait référence. Pour les **vérifications et tests**, voir [`TESTING.md`](TESTING.md).
+Pour les **conventions de contenu et de formatage des fiches** (header, callouts, images, footer, catalogue), voir [`CONVENTIONS.md`](CONVENTIONS.md) qui fait autorité. Pour les **vérifications et tests**, voir [`TESTING.md`](TESTING.md).
 
 ## À qui s'adresse ce document
 
@@ -42,17 +42,18 @@ Le `npm ci` à la racine installe automatiquement les **hooks Git** (husky) qui 
 
 Depuis la racine du repo :
 
-| Commande                 | Description                                      |
-| ------------------------ | ------------------------------------------------ |
-| `npm run format`         | Formate tous les fichiers (Prettier)             |
-| `npm run format:check`   | Vérifie le formatage                             |
-| `npm run lint:md`        | Vérifie le Markdown (markdownlint)               |
-| `npm run lint:md:fix`    | Corrige automatiquement le Markdown              |
-| `npm run lint:spell`     | Vérifie l'orthographe (cspell, FR + EN)          |
-| `npm run lint:links`     | Vérifie les liens externes (Docker requis, lent) |
-| `npm run site:start`     | Raccourci vers `npm start` dans `site/`          |
-| `npm run site:build`     | Raccourci vers `npm run build` dans `site/`      |
-| `npm run site:typecheck` | Raccourci vers `npm run typecheck` dans `site/`  |
+| Commande                 | Description                                                            |
+| ------------------------ | ---------------------------------------------------------------------- |
+| `npm run format`         | Formate tous les fichiers (Prettier)                                   |
+| `npm run format:check`   | Vérifie le formatage                                                   |
+| `npm run lint:md`        | Vérifie le Markdown (markdownlint)                                     |
+| `npm run lint:md:fix`    | Corrige automatiquement le Markdown                                    |
+| `npm run lint:spell`     | Vérifie l'orthographe (cspell, FR + EN)                                |
+| `npm run lint:links`     | Vérifie les liens externes (Docker requis, lent)                       |
+| `npm run site:start`     | Raccourci vers `npm start` dans `site/`                                |
+| `npm run site:build`     | Raccourci vers `npm run build` dans `site/`                            |
+| `npm run site:typecheck` | Raccourci vers `npm run typecheck` dans `site/`                        |
+| `npm run site:clean`     | Nettoie `site/build`, `site/.docusaurus`, et artefacts `*.js` dans src |
 
 ## Workflow de contribution
 
@@ -158,7 +159,7 @@ Installés via `npm ci` à la racine. Ils s'exécutent à chaque commit sans act
 
 1. Créer une issue avec le template **Nouvelle fiche** ([.github/ISSUE_TEMPLATE/fiche.md](.github/ISSUE_TEMPLATE/fiche.md)).
 2. Créer une branche `content/<id-de-la-fiche>` ou `feat/<projet>-<id>`.
-3. Créer le fichier markdown dans `site/docs/<projet>/<id-fiche>.md` en suivant le format de [`CLAUDE.md`](CLAUDE.md) (header flex, badges, tableau, callouts, footer).
+3. Créer le fichier markdown dans `site/docs/<projet>/<id-fiche>.md` en suivant les règles de [`CONVENTIONS.md`](CONVENTIONS.md) (header flex, badges, tableau, callouts, footer).
 4. Créer le dossier d'images correspondant : `site/static/img/ressources/<projet>/<id-fiche>/` (avec au minimum `icone.png` ou `icone.svg`).
 5. Si un PDF accompagne la fiche : `site/static/pdf/<projet>/<nom>.pdf`.
 6. Ajouter une entrée dans le catalogue [`site/src/data/resources.ts`](site/src/data/resources.ts) avec tous les champs requis (`id`, `title`, `slug`, `project`, `summary`, `disciplines`, `tools`, `software`, `ageMin`, `ageMax`, `durationMinutes`, `difficulty`, `formats`, `categories`, `keywords`, `pdf?`, `thumbnail?`).
@@ -166,7 +167,7 @@ Installés via `npm ci` à la racine. Ils s'exécutent à chaque commit sans act
 
 ### Modifier une fiche existante
 
-- Conserver le format défini dans [`CLAUDE.md`](CLAUDE.md).
+- Conserver le format défini dans [`CONVENTIONS.md`](CONVENTIONS.md).
 - Si le sujet/durée/difficulté change, mettre à jour aussi l'entrée dans `resources.ts`.
 - Pour les changements importants, mentionner dans la PR si une re-validation pédagogique est nécessaire.
 
@@ -190,7 +191,7 @@ Issue avec le template **Bug** ([.github/ISSUE_TEMPLATE/bug.md](.github/ISSUE_TE
 
 ## Conventions de contenu (fiches)
 
-→ Voir [`CLAUDE.md`](CLAUDE.md) en détail. Points clés :
+→ Voir [`CONVENTIONS.md`](CONVENTIONS.md) en détail. Points clés :
 
 - Header flex : titre + icône SVG + badges + tableau + matériel + bouton PDF (selon disponibilité)
 - Callouts : `:::tip` réservé aux ressources imprimables, `:::info` pour les conseils, `:::caution` pour les phases d'activité
@@ -226,7 +227,7 @@ Issue avec le template **Bug** ([.github/ISSUE_TEMPLATE/bug.md](.github/ISSUE_TE
 ## Process de revue
 
 - Une PR doit être validée par **au moins un autre membre de l'équipe Wiki** avant merge.
-- Les revues portent sur le contenu pédagogique (fiches), le formatage (conventions `CLAUDE.md`), et la qualité technique (code).
+- Les revues portent sur le contenu pédagogique (fiches), le formatage (conventions `CONVENTIONS.md`), et la qualité technique (code).
 - En cas de désaccord sur le contenu pédagogique, le mainteneur du projet concerné tranche.
 
 ## Protection de la branche `main`
@@ -236,11 +237,19 @@ Issue avec le template **Bug** ([.github/ISSUE_TEMPLATE/bug.md](.github/ISSUE_TE
 - 1 approbation de review requise
 - Squash merge (historique linéaire)
 
+## Suivi du projet
+
+- **Issues** : <https://github.com/LabAixBidouille/wikilab/issues>
+- **Milestones** : 7 jalons structurants de l'initiative STeaMi/MicroPython (Bootstrap, Fiches enseignants, Portage Let's STEAM, Outillage CI, Harmonisation P1, Audit phase 2, Portage phase 2). Voir <https://github.com/LabAixBidouille/wikilab/milestones>.
+- **Project board** : <https://github.com/orgs/LabAixBidouille/projects/1>
+- **Issue types** (de l'org `LabAixBidouille`) : `Task` pour les tâches concrètes, `Feature` pour les EPICs et grandes initiatives, `Bug` pour les défauts. Le type est posé sur l'issue (champ GitHub natif), au-delà des labels.
+- **Labels usuels** : `epic`, `phase-1`, `phase-2`, `prepa`, `steami`, `micropython`, `fiche-portage`, `fiche-enseignant`, `outillage`, `audit`, `bug`, `documentation`.
+
 ## Ressources et contact
 
 - **Repo** : <https://github.com/LabAixBidouille/wikilab>
 - **Site en prod** : <https://wiki.labaixbidouille.com>
-- **Conventions de fiches détaillées** : [`CLAUDE.md`](CLAUDE.md)
+- **Conventions de contenu et de fiches** : [`CONVENTIONS.md`](CONVENTIONS.md)
 - **Tests et vérifications** : [`TESTING.md`](TESTING.md)
 - **Contact** : <contact@labaixbidouille.com>
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -1,0 +1,196 @@
+# Conventions de contenu — Wiki@LAB
+
+Ce document fait autorité pour le **formatage des fiches pédagogiques** et leur intégration au catalogue. Tout contributeur de contenu doit s'y référer.
+
+> Pour le **workflow git/PR/CI** : voir [`CONTRIBUTING.md`](CONTRIBUTING.md).
+> Pour les **vérifications et tests** : voir [`TESTING.md`](TESTING.md).
+
+## Sommaire
+
+1. [Header (en-tête de fiche)](#header-en-tête-de-fiche)
+2. [Structure des fiches](#structure-des-fiches)
+3. [Callouts](#callouts)
+4. [Images](#images)
+5. [Texte](#texte)
+6. [Contenu à supprimer](#contenu-à-supprimer)
+7. [Notes enseignants](#notes-enseignants)
+8. [Catalogue (`resources.ts`)](#catalogue-resourcests)
+9. [Suivi photos](#suivi-photos)
+10. [Sous-pages (borne-arcade, programmation)](#sous-pages-borne-arcade-programmation)
+11. [Fiches de programmation extraites](#fiches-de-programmation-extraites)
+12. [Couleurs des projets](#couleurs-des-projets)
+
+## Header (en-tête de fiche)
+
+- Flex layout : titre + badges + tableau + matériel + PDF + callout à gauche, icône 225px à droite
+- Titre H1 avec icône SVG flat design inline (couleur du projet, opacités 0.1/0.25/1.0)
+- Badges : disciplines (primary), outils (info), logiciels (warning/secondary)
+- Tableau : colonnes égales, en-tête fond `#09246C` + texte blanc (sera adapté par projet, [TODO ouvert](https://github.com/LabAixBidouille/wikilab/issues))
+- Bouton PDF rose (`#e83e8c`) si PDF disponible
+- Callout `:::tip[**Ressources imprimables incluses dans le PDF.**]` avec liste si applicable
+
+## Structure des fiches
+
+Règles consolidées (héritées de la refonte SteamCity) :
+
+- **Introduction** (H2) contient : texte d'intro, Structure du protocole (H3), tableau durée/matériel sans titre "Pour bien démarrer", Glossaire (H3) en liste à puces
+- **Pas de titre `## Protocole`** : les phases sont directement H2
+- **Phases** : `## Phase 1 : Compréhension...` (majuscule après `:`)
+- **Sous-sections des phases** : Conceptualisation, Investigation, Analyse en H3
+- **Fiches programmation** : extraites dans `docs/<projet>/programmation/` avec lien dans la fiche principale (voir [Fiches de programmation extraites](#fiches-de-programmation-extraites))
+
+## Callouts
+
+### Standard Docusaurus
+
+- `:::tip` (vert, icône imprimante) : ressources imprimables UNIQUEMENT
+- `:::info` (bleu, icône info/ampoule) : conseils, remarques, notes techniques
+- `:::caution` (rose, icône ▶) : phases d'activité
+- `:::note` (gris) : notes diverses
+
+### Custom (Wiki@LAB)
+
+Déclarés dans [`site/docusaurus.config.ts`](site/docusaurus.config.ts) (`admonitions.keywords`) et implémentés dans [`site/src/theme/Admonition/Type/`](site/src/theme/Admonition/Type/).
+
+- `:::question` (violet, icône `?`) : question de recherche scientifique
+- `:::hypothese` (sarcelle/teal, icône ampoule) : hypothèse à vérifier
+
+Couleurs et icônes : voir [`site/src/css/custom.css`](site/src/css/custom.css) (sections `theme-admonition-question` et `theme-admonition-hypothese`).
+
+### Règles
+
+- Ne JAMAIS utiliser `:::tip` pour des conseils non-imprimables
+- Le titre par défaut est posé par le composant — surcharger avec `:::question[Mon titre]` si besoin
+- Pour ajouter un nouveau type custom : 1) déclarer le keyword dans `docusaurus.config.ts`, 2) créer le composant dans `site/src/theme/Admonition/Type/`, 3) référencer dans `site/src/theme/Admonition/Types.tsx`, 4) ajouter le CSS dans `custom.css`
+
+## Images
+
+- En bloc, alignées à gauche par défaut (CSS global `display: block`)
+- Placées **après** le texte descriptif qu'elles illustrent
+- Légendes UNIQUEMENT si demandé explicitement (style global déjà appliqué : italique, 0.9em, gris foncé, **centré** via `.markdown figcaption`)
+- **RÈGLE STRICTE** : dès qu'une `<figcaption>` est présente, l'image ET la légende DOIVENT être centrées. Le CSS global `.markdown figure:has(figcaption)` applique le centrage automatiquement, mais il faut quand même appliquer le pattern :
+
+  ```jsx
+  <figure style={{ margin: '1rem auto', textAlign: 'center' }}>
+    <img src="..." style={{ maxWidth: '100%', height: 'auto', margin: '0 auto' }} />
+    <figcaption style={{ margin: 0 }}>...</figcaption>
+  </figure>
+  ```
+
+  NE JAMAIS laisser une image avec figcaption alignée à gauche.
+
+- **Images côte à côte sans étirement** : flex container avec `alignItems: 'flex-start'` et chaque image en `maxWidth: 'calc(50% - 1rem)'` + `height: 'auto'` + `alignSelf: 'flex-start'` (préserve les proportions naturelles, espace vide sous la plus petite si tailles différentes — c'est OK)
+
+  ```jsx
+  <div style={{ display: 'flex', gap: '2rem', alignItems: 'flex-start', flexWrap: 'wrap' }}>
+    <img
+      src="..."
+      style={{ maxWidth: 'calc(50% - 1rem)', height: 'auto', alignSelf: 'flex-start' }}
+    />
+    <img
+      src="..."
+      style={{ maxWidth: 'calc(50% - 1rem)', height: 'auto', alignSelf: 'flex-start' }}
+    />
+  </div>
+  ```
+
+- Centrage figure + image : `<figure style={{width: 'X%', margin: '1rem auto'}}><img style={{width: '100%'}}/></figure>`
+
+## Texte
+
+- Justifié (CSS global)
+- Titres numérotés de manière homogène (Partie 1, 2, 3...)
+- Pas de bold dans les headings
+- `--` dans les titres → `:` + majuscule après (règle wiki globale)
+- Listes avec deux-points → premier élément en gras : `- **Label** : description`
+- Footer Erasmus+ en bas de chaque fiche concernée
+- Gras pour : "Contexte de la séquence" et "Objectifs d'apprentissage"
+
+## Contenu à supprimer
+
+Lors de la conversion d'un PDF/source vers une fiche wiki :
+
+- Mentions italiques de phase (Découverte et échauffement, Fin de la séquence...)
+- Blockquotes citations en début de page → texte normal
+- Doubles `---` en fin de fiche
+- Mentions "Une activité développée par..."
+- Références QR code → "disponible dans le PDF"
+- Glossaires en tableau → listes à puces
+
+## Notes enseignants
+
+- Format : `:::info[Notes pour l'enseignant·e]` (bleu, pas gris)
+- Convertir tous les blockquotes `> **Notes pour l'enseignant·e**` en callouts info
+
+## Catalogue (`resources.ts`)
+
+Source : [`site/src/data/resources.ts`](site/src/data/resources.ts).
+
+Chaque fiche est une entrée avec :
+
+- `id` (kebab-case, unique)
+- `title`, `slug` (chemin URL `/ressources/<projet>/<id>`)
+- `project` (un de `lets-steam`, `mimesis`, `unplugged`, `jeditrack`, `robots-meet-arts`, `steamcity`, `thedexterlab`, `youth-ai-lab`, `inovmicro-exao`, `projets-du-lab`)
+- `summary` (1-2 phrases)
+- `disciplines`, `tools`, `software` (unions de types stricts)
+- `ageMin`, `ageMax` (entiers)
+- `durationMinutes` (max 240 — au-delà la fiche est trop longue)
+- `difficulty` (`debutant` | `intermediaire` | `avance`)
+- `formats` (un ou plusieurs parmi `debranchee`, `programmation`, `experimentation`, `jeu-de-role`, `bricolage`, `enquete`, `projet-maker`)
+- `categories` : 11 approches pédagogiques, multi-catégories autorisées :
+  - `programmation`, `exploration-scientifique`, `robotique-ludique`, `animation-jeunesse`
+  - `citoyennete-territoire`, `ia-esprit-critique`, `sequences-debranchees`
+  - `theatre-sciences`, `arts-creativite`, `environnement-nature`, `makers-fabrication`
+- `keywords` (mots-clés pour la recherche)
+- `pdf?` (chemin optionnel vers le PDF)
+- `thumbnail?` (chemin optionnel vers `/img/ressources/<projet>/<id>/icone.png` ou `.svg`)
+
+Les types sont stricts : ajouter une nouvelle valeur impose d'éditer le type au début du fichier.
+
+## Suivi photos
+
+- Page interactive : `/photos-suivi` (cases à cocher avec persistance localStorage)
+- Convention : un sous-dossier par fiche sous `site/static/img/ressources/<projet>/<fiche-id>/`
+- Le dossier de chaque fiche doit contenir `icone.png`/`icone.svg` + photos additionnelles
+- Exception : `projets-du-lab/` racine contient le dump d'images historique (référencé dans les MD), plus les sous-dossiers `lab-<id>/` pour les icônes
+
+## Sous-pages (borne-arcade, programmation)
+
+- Dossier dans `docs/<projet>/<sous-projet>/`
+- Fichier `_category_.json` avec `label`, `position`, `collapsed`
+- Ajouter une entrée au catalogue pointant vers la page d'introduction/première page
+
+## Fiches de programmation extraites
+
+Les fiches longues (SteamCity, TheDexterLab) qui contiennent des sections de programmation doivent avoir ces sections **extraites** dans `docs/<projet>/programmation/`.
+
+**Format obligatoire** : même format qu'une fiche Let's STEAM (référence : [`docs/lets-steam/r1as01-led.md`](site/docs/lets-steam/r1as01-led.md)) :
+
+- Flex header complet avec SVG icône couleur projet, badges (discipline, carte, logiciel), tableau Projet/Durée/Difficulté/Âge
+- Section `## Matériel`
+- Bouton PDF si disponible
+- Section `## De quoi parle-t-on ?` avec intro sur le concept/hardware
+- Section `## Objectifs d'apprentissage` en liste à puces
+- Contenu de programmation (étapes, code, câblage)
+- Footer Erasmus+
+
+Dans la fiche principale, remplacer la section extraite par un lien `## Programmation` pointant vers la fiche technique.
+
+Les tableaux vides (exemples à remplir) doivent avoir des lignes de taille égale (même nombre de cellules).
+
+## Couleurs des projets
+
+| Projet           | Couleur principale |
+| ---------------- | ------------------ |
+| Let's STEAM      | `#140e4e`          |
+| Mimesis          | `#09246C`          |
+| Unplugged        | `#0081A7`          |
+| JediTrack        | `#1198f0`          |
+| Robots Meet Arts | `#169da7`          |
+| SteamCity        | `#DD5350`          |
+| The Dexter Lab   | `#1a4a48`          |
+| Youth AI Lab     | `#b34520`          |
+| I-Novmicro #2    | `#8a6e18`          |
+| Projets du LAB   | (variable)         |
+
+À utiliser pour : icône SVG inline du header (avec opacités 0.1/0.25/1.0), code couleur de l'entrée projet dans [`site/src/data/projects.ts`](site/src/data/projects.ts).

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -37,7 +37,7 @@ Règles consolidées (héritées de la refonte SteamCity) :
 - **Pas de titre `## Protocole`** : les phases sont directement H2
 - **Phases** : `## Phase 1 : Compréhension...` (majuscule après `:`)
 - **Sous-sections des phases** : Conceptualisation, Investigation, Analyse en H3
-- **Fiches programmation** : extraites dans `docs/<projet>/programmation/` avec lien dans la fiche principale (voir [Fiches de programmation extraites](#fiches-de-programmation-extraites))
+- **Fiches programmation** : extraites dans `site/docs/<projet>/programmation/` avec lien dans la fiche principale (voir [Fiches de programmation extraites](#fiches-de-programmation-extraites))
 
 ## Callouts
 
@@ -156,15 +156,15 @@ Les types sont stricts : ajouter une nouvelle valeur impose d'éditer le type au
 
 ## Sous-pages (borne-arcade, programmation)
 
-- Dossier dans `docs/<projet>/<sous-projet>/`
+- Dossier dans `site/docs/<projet>/<sous-projet>/`
 - Fichier `_category_.json` avec `label`, `position`, `collapsed`
 - Ajouter une entrée au catalogue pointant vers la page d'introduction/première page
 
 ## Fiches de programmation extraites
 
-Les fiches longues (SteamCity, TheDexterLab) qui contiennent des sections de programmation doivent avoir ces sections **extraites** dans `docs/<projet>/programmation/`.
+Les fiches longues (SteamCity, TheDexterLab) qui contiennent des sections de programmation doivent avoir ces sections **extraites** dans `site/docs/<projet>/programmation/`.
 
-**Format obligatoire** : même format qu'une fiche Let's STEAM (référence : [`docs/lets-steam/r1as01-led.md`](site/docs/lets-steam/r1as01-led.md)) :
+**Format obligatoire** : même format qu'une fiche Let's STEAM (référence : [`site/docs/lets-steam/r1as01-led.md`](site/docs/lets-steam/r1as01-led.md)) :
 
 - Flex header complet avec SVG icône couleur projet, badges (discipline, carte, logiciel), tableau Projet/Durée/Difficulté/Âge
 - Section `## Matériel`

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Wiki des ressources pédagogiques du **L.A.B — Laboratoire d'Aix-périmentation et de Bidouille**.
 
-Catalogue de 184 fiches issues de projets éducatifs, créatifs et makers (programmation, robotique, IA, fabrication numérique, débranché, théâtre des sciences…), publiées sous **Creative Commons BY-SA 4.0**.
+Catalogue de 185 fiches issues de projets éducatifs, créatifs et makers (programmation, robotique, IA, fabrication numérique, débranché, théâtre des sciences…), publiées sous **Creative Commons BY-SA 4.0**.
 
 🌐 **Site en ligne** : <https://wiki.labaixbidouille.com>
 
@@ -17,22 +17,34 @@ Catalogue de 184 fiches issues de projets éducatifs, créatifs et makers (progr
 | Robots Meet Arts |                  29 | `#169da7` |
 | SteamCity        |         25 + 9 prog | `#DD5350` |
 | The Dexter Lab   |        20 + 13 prog | `#1a4a48` |
-| Youth AI Lab     |                   5 | `#b34520` |
+| Youth AI Lab     |                   6 | `#b34520` |
 | I-Novmicro #2    |                   1 | `#8a6e18` |
 | Projets du LAB   |                  20 | —         |
 
 ## Architecture
 
-- **Framework** : [Docusaurus v4](https://docusaurus.io/) (TypeScript)
-- **Site** : [`site/`](site/)
+### Site Docusaurus (`site/`)
+
+- **Framework** : [Docusaurus v4](https://docusaurus.io/) (TypeScript, mode strict)
 - **Config** : [`site/docusaurus.config.ts`](site/docusaurus.config.ts)
-- **Catalogue** : [`site/src/data/resources.ts`](site/src/data/resources.ts)
+- **Catalogue typé** : [`site/src/data/resources.ts`](site/src/data/resources.ts)
+- **Données projets** : [`site/src/data/projects.ts`](site/src/data/projects.ts)
+- **Pages custom** : [`site/src/pages/`](site/src/pages/) (catalogue, projets, machines, index)
+- **Theme custom** : [`site/src/theme/`](site/src/theme/) (admonitions custom `:::question`, `:::hypothese`)
+- **Types globaux** : [`site/src/types/`](site/src/types/) (extension `React.CSSProperties` pour les CSS variables)
 - **Fiches** : [`site/docs/<projet>/`](site/docs/)
 - **Images** : [`site/static/img/ressources/<projet>/<fiche-id>/`](site/static/img/ressources/)
 - **PDFs** : [`site/static/pdf/<projet>/`](site/static/pdf/)
-- **Sources markdown brutes** : [`markdown/`](markdown/)
+- **Sources markdown brutes** : [`markdown/`](markdown/) (originaux pré-conversion)
 
-Voir [`CLAUDE.md`](CLAUDE.md) pour les conventions de formatage, la structure des fiches et les règles de contribution détaillées.
+### Outillage qualité (racine)
+
+- **`package.json` racine** : Prettier, markdownlint, cspell, husky, commitlint, lint-staged, validate-branch-name, lychee
+- **Hooks Git** : [`.husky/pre-commit`](.husky/pre-commit), [`.husky/commit-msg`](.husky/commit-msg)
+- **CI/CD** : [`.github/workflows/`](.github/workflows/) (build, deploy, links cron, auto-assign)
+- **Templates** : [`.github/ISSUE_TEMPLATE/`](.github/ISSUE_TEMPLATE/), [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md)
+
+Pour les **conventions de contenu et de formatage des fiches**, voir [`CONVENTIONS.md`](CONVENTIONS.md).
 
 ## Développement local
 
@@ -61,8 +73,16 @@ Le site est déployé automatiquement sur **GitHub Pages** via [`.github/workflo
 ## Contribution
 
 - **Comment contribuer** (workflow, branches, PR, checklists) : voir [`CONTRIBUTING.md`](CONTRIBUTING.md)
+- **Conventions de contenu et formatage des fiches** : voir [`CONVENTIONS.md`](CONVENTIONS.md)
 - **Tests et vérifications** (build, typecheck, lint, CI) : voir [`TESTING.md`](TESTING.md)
-- **Conventions de formatage des fiches** (header, callouts, images, footer) : voir [`CLAUDE.md`](CLAUDE.md)
+- **Notes pour assistants IA** (architecture, contexte projet) : voir [`CLAUDE.md`](CLAUDE.md)
+
+## Suivi du projet
+
+- **Issues** : <https://github.com/LabAixBidouille/wikilab/issues>
+- **Milestones** : structuration en 7 jalons (Bootstrap, Fiches enseignants, Portage Let's STEAM, Outillage CI, Harmonisation P1, Audit phase 2, Portage phase 2) — voir <https://github.com/LabAixBidouille/wikilab/milestones>
+- **Project board** : <https://github.com/orgs/LabAixBidouille/projects/1>
+- **Initiative en cours** : intégration de la carte STeaMi + MicroPython dans l'écosystème (38 issues, EPICs #2 phase 1 et #30 phase 2)
 
 ## Licence
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Catalogue de 185 fiches issues de projets éducatifs, créatifs et makers (progr
 
 ### Site Docusaurus (`site/`)
 
-- **Framework** : [Docusaurus v4](https://docusaurus.io/) (TypeScript, mode strict)
+- **Framework** : [Docusaurus v3.10](https://docusaurus.io/) (TypeScript, mode strict ; flag `future.v4: true` activé pour préparer la migration v4)
 - **Config** : [`site/docusaurus.config.ts`](site/docusaurus.config.ts)
 - **Catalogue typé** : [`site/src/data/resources.ts`](site/src/data/resources.ts)
 - **Données projets** : [`site/src/data/projects.ts`](site/src/data/projects.ts)

--- a/TESTING.md
+++ b/TESTING.md
@@ -193,7 +193,7 @@ Mots à éviter (équivalents accentués préférés) listés dans `cspell.json`
 
 ## Ressources
 
-- [Documentation Docusaurus v4](https://docusaurus.io/docs)
+- [Documentation Docusaurus v3](https://docusaurus.io/docs)
 - [Conventions de contenu](CONVENTIONS.md)
 - [Workflow de contribution](CONTRIBUTING.md)
 - [Issues outillage CI](https://github.com/LabAixBidouille/wikilab/issues?q=is%3Aissue+label%3Aoutillage)

--- a/TESTING.md
+++ b/TESTING.md
@@ -194,6 +194,6 @@ Mots à éviter (équivalents accentués préférés) listés dans `cspell.json`
 ## Ressources
 
 - [Documentation Docusaurus v4](https://docusaurus.io/docs)
-- [Conventions de contenu](CLAUDE.md)
+- [Conventions de contenu](CONVENTIONS.md)
 - [Workflow de contribution](CONTRIBUTING.md)
 - [Issues outillage CI](https://github.com/LabAixBidouille/wikilab/issues?q=is%3Aissue+label%3Aoutillage)


### PR DESCRIPTION
## Résumé

Refactorise la documentation projet pour donner aux contributeurs humains une source claire et faisant autorité sur les conventions de contenu, et clarifier le rôle de CLAUDE.md.

### Changement principal — `CONVENTIONS.md` (nouveau)

Tout le contenu "Conventions de formatage des fiches" qui vivait dans `CLAUDE.md` est extrait dans un nouveau document à la racine : [`CONVENTIONS.md`](../CONVENTIONS.md).

Ce document fait désormais autorité pour :

- Header (en-tête de fiche)
- Structure des fiches (règles SteamCity)
- Callouts (standard + custom `:::question`/`:::hypothese`)
- Images (alignement, légendes, côte à côte)
- Texte (typographie, justification, footers)
- Contenu à supprimer lors de la conversion
- Notes enseignants
- Catalogue (`resources.ts`) — tous les champs et leurs types
- Suivi photos
- Sous-pages (borne-arcade, programmation)
- Fiches de programmation extraites
- Couleurs des projets

### Changements dans les autres docs

- **CLAUDE.md** : allégé. Garde l'architecture, le build, le suivi des travaux. Devient explicitement "notes pour assistants IA". Pointe vers CONVENTIONS.md pour le formatage.
- **README.md** : compteurs à jour (Youth AI Lab 5→6, total 184→185), section Architecture étoffée (theme custom, types globaux, outillage racine), nouvelle section "Suivi du projet" (issues/milestones/board).
- **CONTRIBUTING.md** : ajoute `npm run site:clean` au tableau, nouvelle section "Suivi du projet" (issue types, labels usuels), redirige vers CONVENTIONS.md.
- **TESTING.md** : redirige vers CONVENTIONS.md.

### Dico cspell

Étendu pour les identifiants TypeScript en kebab-case ASCII (debranchee, enquete, intermediaire, debutant, avance, etc.) — ce sont des contraintes de typage, pas des fautes.

## Type de changement

- [x] Contenu — fiche, doc, texte
- [ ] Catalogue — entrée(s) dans `resources.ts` ou `projects.ts`
- [ ] Code — composant React, page, type, CSS
- [ ] Configuration — config Docusaurus, CI, hooks

## Test plan

- [x] `npm run format:check` passe
- [x] `npm run lint:md` passe
- [x] `npm run lint:spell` passe
- [x] `npm run site:typecheck` passe
- [x] Tous les liens entre docs sont cohérents (CONVENTIONS ↔ CONTRIBUTING ↔ TESTING ↔ README ↔ CLAUDE)
- [x] Aucun lien interne mort
- [x] CONVENTIONS.md est complet et auto-suffisant pour un nouveau contributeur

## Issues liées

Refs #39 — répond au feedback "les conventions de fiches devraient avoir une visibilité plus directe que CLAUDE.md".