### PR TITLE
docs: workflow PR obligatoire — instructions explicites pour les IA

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,30 @@
 > - Tests et vérifications → [`TESTING.md`](TESTING.md)
 > - Présentation du projet → [`README.md`](README.md)
 
+## ⚠️ Workflow obligatoire — toute modification passe par une issue + une PR
+
+**Cette règle est absolue, sans exception, y compris pour les corrections triviales.** La branche `main` est protégée côté GitHub : un push direct sera rejeté par le serveur. N'essaie pas de contourner cette protection.
+
+Pour toute modification, **avant** de modifier le code :
+
+1. **S'assurer qu'une issue existe** pour décrire le travail. Si elle n'existe pas, l'ouvrir (`gh issue create`) avec le bon template (bug / fiche / illustration), label, milestone et type. Référencer cette issue dans le commit et la PR (`Refs #N` ou `Closes #N`).
+2. **Créer une branche dédiée** depuis `main` à jour. Le format est validé automatiquement par `validate-branch-name` (hook pre-commit) : `feat/<kebab>`, `fix/<kebab>`, `docs/<kebab>`, `ci/<kebab>`, `chore/<kebab>`, `refactor/<kebab>`, `content/<kebab>`, ou `release/vX.Y.Z`.
+3. **Commiter** avec des messages aux **Conventional Commits** (validés par `commitlint`, hook commit-msg) : `<type>(<scope>): <description>`.
+4. **Faire passer les checks locaux** (voir [`TESTING.md`](TESTING.md)) : `format:check`, `lint:md`, `lint:spell`, `site:typecheck`, `site:build`.
+5. **Pousser la branche** et **ouvrir une Pull Request** vers `main` (`gh pr create`). La PR doit suivre le template ([`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md)).
+6. **Attendre la CI** (workflow `build.yml` : lint + typecheck + build) et **au moins une approbation humaine** avant tout merge.
+7. **Ne jamais merger soi-même sans accord humain.** L'humain pilote, l'IA propose.
+
+Détails complets du workflow et des conventions : [`CONTRIBUTING.md`](CONTRIBUTING.md).
+
+### Si tu détectes une dette ou un correctif rapide
+
+Même flux : issue → branche → PR. Pas de raccourci, même pour un typo. Le prix d'une PR de 2 minutes est dérisoire face à la traçabilité gagnée.
+
+### Si l'humain te demande de pousser direct
+
+Refuser et expliquer la règle. Proposer le flux PR. Si l'humain insiste explicitement et est admin du repo, c'est sa responsabilité — mais alerter d'abord, et privilégier la PR même expéditive (auto-merge possible une fois la CI verte).
+
 ## Architecture
 
 ### Site Docusaurus (`site/`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,9 @@ Depuis la racine du repo :
 
 ## Workflow de contribution
 
-1. **Créer une issue** décrivant le changement (sauf typo trivial).
+> **La branche `main` est protégée**. Toute modification — y compris correction de typo — passe obligatoirement par une issue et une PR. Cela vaut pour les contributeurs humains comme pour les **assistants IA** (Claude Code, Copilot, etc.) qui interviennent sur ce repo. Le push direct sur `main` est rejeté par GitHub. Voir [`CLAUDE.md`](CLAUDE.md) pour les instructions spécifiques aux assistants IA.
+
+1. **Créer une issue** décrivant le changement (sauf typo trivial — et encore, préférer une issue).
 2. **Créer une branche** depuis `main` au format conventionnel (voir ci-dessous).
 3. **Développer** en commitant régulièrement avec des messages aux Conventional Commits.
 4. **Vérifier localement** :


### PR DESCRIPTION
## Résumé

Plusieurs sessions ont vu des assistants IA (Claude Code et autres) tenter de pousser directement sur `main` — la protection de branche les bloque, mais c'est une perte de temps et un signal de mauvaise pratique. Cette PR rend la règle explicite et obligatoire dans la documentation IA.

### Changements

- **CLAUDE.md** : nouvelle section ⚠️ **"Workflow obligatoire — toute modification passe par une issue + une PR"** en tête de fichier (juste après le bandeau humains/IA). Décrit les 7 étapes du flux (issue → branche → commit → checks → push → PR → review humaine → merge) et 2 cas particuliers :
  - "Dette ou correctif rapide" → même flux, pas de raccourci, même pour un typo
  - "L'humain demande de pousser direct" → refuser, expliquer la règle, proposer le flux PR
- **CONTRIBUTING.md** : encart en tête de "Workflow de contribution" qui précise que la règle s'applique aux humains comme aux **IA**, et renvoie vers CLAUDE.md.

## Type de changement

- [x] Contenu — fiche, doc, texte
- [ ] Catalogue
- [ ] Code
- [ ] Configuration

## Test plan

- [x] `npm run format:check` passe
- [x] `npm run lint:md` passe
- [x] `npm run lint:spell` passe
- [x] L'instruction est en tête de CLAUDE.md (visible immédiatement)
- [x] CONTRIBUTING.md référence CLAUDE.md pour les IA

## Issues liées

(Pas d'issue associée — directement issu d'un retour utilisateur.)