### PR TITLE
fix(magnetics): mise en page images des fiches

### DIFF
--- a/site/docs/magnetics/makecode-stm32.md
+++ b/site/docs/magnetics/makecode-stm32.md
@@ -70,6 +70,9 @@ Pour réaliser cette activité nous avons besoin de **quatre cartes STM32 IoT No
 
 #### 1. Câbler l'écran OLED
 
+<div style={{display: 'flex', gap: '1.5rem', alignItems: 'flex-start', flexWrap: 'wrap', margin: '0.75rem 0'}}>
+<div style={{flex: '1 1 320px', minWidth: '280px'}}>
+
 Nous devons en premier lieu câbler l'écran OLED directement à la carte collectrice. Il y a deux façons de câbler l'écran **OLED SSD1306** à une carte, soit avec une connexion **I2C** ou **SPI**. Pour notre écran, nous utilisons la connexion I2C via le câble **QWIIC/STEMMA** avec la convention suivante :
 
 - **Noir** pour GND
@@ -77,7 +80,9 @@ Nous devons en premier lieu câbler l'écran OLED directement à la carte collec
 - **Bleu** pour SDA (D14)
 - **Jaune** pour SCL (D15)
 
-<img src="/img/ressources/magnetics/makecode-stm32/oled.png" alt="Câblage de l'écran OLED sur la carte collectrice" style={{maxWidth: '60%', height: 'auto', margin: '0.75rem 0'}} />
+</div>
+<img src="/img/ressources/magnetics/makecode-stm32/oled.png" alt="Câblage de l'écran OLED sur la carte collectrice" style={{flex: '0 1 280px', maxWidth: '280px', height: 'auto', alignSelf: 'flex-start'}} />
+</div>
 
 #### 2. Connecter la carte à l'ordinateur
 

--- a/site/docs/magnetics/microbit.md
+++ b/site/docs/magnetics/microbit.md
@@ -169,9 +169,10 @@ magnetics.setAdvertisingKeyValueData("Temp (°C)", input.temperature())
 })
 ```
 
-<img src="/img/ressources/magnetics/microbit/blocs-emettrice-temperature.png" alt="Blocs pour le code de la carte émettrice de la température" style={{maxWidth: '70%', height: 'auto', margin: '0.75rem 0'}} />
-
-<img src="/img/ressources/magnetics/microbit/exemple-editeur-bloc-emettrice-temperature.png" alt="Exemple de l'éditeur en mode bloc pour le code de la carte émettrice de la température" style={{maxWidth: '90%', height: 'auto', margin: '0.75rem 0'}} />
+<div style={{display: 'flex', gap: '1.5rem', alignItems: 'flex-start', flexWrap: 'wrap', margin: '0.75rem 0'}}>
+  <img src="/img/ressources/magnetics/microbit/blocs-emettrice-temperature.png" alt="Blocs pour le code de la carte émettrice de la température" style={{maxWidth: 'calc(50% - 0.75rem)', height: 'auto', alignSelf: 'flex-start'}} />
+  <img src="/img/ressources/magnetics/microbit/exemple-editeur-bloc-emettrice-temperature.png" alt="Exemple de l'éditeur en mode bloc pour le code de la carte émettrice de la température" style={{maxWidth: 'calc(50% - 0.75rem)', height: 'auto', alignSelf: 'flex-start'}} />
+</div>
 
 ### Code de la carte émettrice de l'intensité lumineuse
 

--- a/site/docs/magnetics/micropython.md
+++ b/site/docs/magnetics/micropython.md
@@ -70,6 +70,9 @@ Pour réaliser cette activité nous avons besoin de **quatre cartes STM32 IoT No
 
 #### 1. Câbler l'écran OLED
 
+<div style={{display: 'flex', gap: '1.5rem', alignItems: 'flex-start', flexWrap: 'wrap', margin: '0.75rem 0'}}>
+<div style={{flex: '1 1 320px', minWidth: '280px'}}>
+
 Nous devons en premier lieu câbler l'écran OLED directement à la carte collectrice. Il y a deux façons de câbler l'écran **OLED SSD1306** à une carte, soit avec une connexion **I2C** ou **SPI**. Pour notre écran, nous utilisons la connexion I2C via le câble **QWIIC/STEMMA** avec la convention suivante :
 
 - **Noir** pour GND
@@ -77,7 +80,9 @@ Nous devons en premier lieu câbler l'écran OLED directement à la carte collec
 - **Bleu** pour SDA (D14)
 - **Jaune** pour SCL (D15)
 
-<img src="/img/ressources/magnetics/micropython/oled.png" alt="Câblage de l'écran OLED sur la carte collectrice" style={{maxWidth: '60%', height: 'auto', margin: '0.75rem 0'}} />
+</div>
+<img src="/img/ressources/magnetics/micropython/oled.png" alt="Câblage de l'écran OLED sur la carte collectrice" style={{flex: '0 1 280px', maxWidth: '280px', height: 'auto', alignSelf: 'flex-start'}} />
+</div>
 
 #### 2. Connecter la carte à l'ordinateur
 


### PR DESCRIPTION
## Summary

- **microbit** : les 2 images (blocs émettrice + exemple éditeur) sont maintenant côte à côte, sur la même ligne, après le code de la carte émettrice de la température.
- **micropython** : l'image OLED est positionnée à droite du texte de l'étape 1 (câblage).
- **makecode-stm32** : même règle — image OLED à droite du texte de l'étape 1.

Pattern flex container avec `flex-wrap` : responsive (l'image passe sous le texte sur mobile).

Closes #50

## Test plan

- [ ] `/ressources/magnetics/microbit` : 2 images côte à côte après code température
- [ ] `/ressources/magnetics/micropython` : OLED à droite du texte étape 1
- [ ] `/ressources/magnetics/makecode-stm32` : OLED à droite du texte étape 1
- [ ] Mobile : layout passe en colonne (responsive)
- [ ] CI verte

🤖 Generated with [Claude Code](https://claude.com/claude-code)