### PR TITLE
style(home): footer compact centré + cartes actions sur 6 colonnes

### DIFF
--- a/site/docusaurus.config.ts
+++ b/site/docusaurus.config.ts
@@ -130,46 +130,6 @@ const config: Config = {
     },
     footer: {
       style: 'dark',
-      links: [
-        {
-          title: 'Navigation',
-          items: [
-            { label: 'À propos', to: '/about' },
-            { label: 'Nos actions', to: '/projets' },
-            { label: 'Catalogue des ressources', to: '/catalogue' },
-            { label: 'Nos machines', to: '/machines' },
-          ],
-        },
-        {
-          title: 'Licence & contact',
-          items: [
-            {
-              label: 'Creative Commons BY-SA 4.0',
-              href: 'https://creativecommons.org/licenses/by-sa/4.0/deed.fr',
-            },
-            {
-              label: 'Contact',
-              href: 'mailto:contact@labaixbidouille.com',
-            },
-          ],
-        },
-        {
-          title: 'Nos actions',
-          items: [
-            { label: 'Projets du LAB', to: '/projets/projets-du-lab' },
-            { label: "Let's STEAM", to: '/projets/lets-steam' },
-            { label: 'Mimesis', to: '/projets/mimesis' },
-            { label: 'Robots Meet Arts', to: '/projets/robots-meet-arts' },
-            { label: 'SteamCity', to: '/projets/steamcity' },
-            { label: 'Unplugged', to: '/projets/unplugged' },
-            { label: 'The Dexter Lab', to: '/projets/the-dexter-lab' },
-            { label: 'JediTrack', to: '/projets/jeditrack' },
-            { label: 'Youth AI Lab', to: '/projets/youth-ai-lab' },
-            { label: 'Magnetics', to: '/projets/magnetics' },
-            { label: 'I-Novmicro #2', to: '/projets/inovmicro-exao' },
-          ],
-        },
-      ],
       copyright: `© ${new Date().getFullYear()} Wiki@LAB — Laboratoire d'Aix-périmentation et de Bidouille. Contenu sous licence Creative Commons BY-SA 4.0.`,
     },
     tableOfContents: {

--- a/site/src/css/custom.css
+++ b/site/src/css/custom.css
@@ -436,15 +436,15 @@ article > table:first-of-type {
 
 .wikilab-projects-grid {
   display: grid;
-  grid-template-columns: repeat(5, 1fr);
-  gap: 1.5rem;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 1rem;
 }
 
 .wikilab-project-card {
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 1.5rem;
+  padding: 1rem;
   border-radius: 12px;
   border: 2px solid var(--ifm-color-emphasis-200);
   background: var(--ifm-background-surface-color, #fff);
@@ -471,10 +471,10 @@ article > table:first-of-type {
 
 .wikilab-project-card__name {
   font-weight: 700;
-  font-size: 0.95rem;
+  font-size: 0.85rem;
   text-align: center;
   margin-top: auto;
-  padding-top: 0.75rem;
+  padding-top: 0.5rem;
 }
 
 /* ── CTA bas de page ── */
@@ -998,31 +998,21 @@ aside input[type='checkbox'] {
 
 .footer--dark {
   background-color: var(--wikilab-purple);
-}
-
-.footer__title {
-  font-weight: 700;
-}
-
-.footer .row {
-  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: auto;
 }
 
 .footer__bottom {
-  margin-top: 2rem;
+  margin-top: 0;
+  text-align: center;
 }
 
-.footer__link-item[href*='/projets/'] {
-  /* handled by parent column layout */
-}
-
-.col.footer__col:nth-child(3) .footer__items {
-  columns: 2;
-  column-gap: 1.5rem;
-}
-
-.col.footer__col:nth-child(3) .footer__items li {
-  break-inside: avoid;
+.footer__copyright {
+  margin: 0;
+  text-align: center;
 }
 
 /* ── Page machines ── */


### PR DESCRIPTION
## Summary

**Footer** :
- Retire les sections navigation/projets/contact (trop de bruit visuel)
- Ne garde que le copyright
- Padding réduit + texte centré (vertical et horizontal via flex)

**Page d'accueil — cartes actions** :
- Grille 5 → 6 colonnes (11 projets : **6 + 5** au lieu de 5 + 5 + 1 orpheline)
- Padding et police légèrement réduits pour des cartes plus compactes

Closes #54

## Test plan

- [ ] Footer : une seule ligne avec le copyright, centré, hauteur réduite
- [ ] Page d'accueil : 6 cartes par ligne, layout 6+5 propre
- [ ] Mobile : grille passe à 3 colonnes (responsive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)