### PR TITLE
chore: ajout fichier de vérification Google Search Console

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,6 +4,7 @@ site/.docusaurus
 site/.cache-loader
 site/static/pdf
 site/static/img
+site/static/google*.html
 site/docs
 site/machines
 site/**/*.js

--- a/site/static/googlef99d962ae4233136.html
+++ b/site/static/googlef99d962ae4233136.html
@@ -1,0 +1,1 @@
+google-site-verification: googlef99d962ae4233136.html


### PR DESCRIPTION
## Summary

Ajout du fichier `googlef99d962ae4233136.html` dans `site/static/` (servi à la racine du site après build).

Permet de valider la propriété du domaine `wiki.labaixbidouille.com` auprès de Google Search Console afin de :

- Soumettre le sitemap (`/sitemap.xml`)
- Demander la suppression des anciennes URLs MediaWiki encore indexées (cf. #62)
- Suivre les performances et erreurs d'indexation

## Test plan

- [ ] Une fois mergé et déployé, vérifier que `https://wiki.labaixbidouille.com/googlef99d962ae4233136.html` retourne le fichier
- [ ] Cliquer "VALIDER" dans Google Search Console → propriété confirmée
- [ ] Soumettre le sitemap dans Search Console
- [ ] Demander la suppression des URLs `/index.php/...` connues

⚠️ Le fichier doit rester en place tant que la vérification est active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)