### PR TITLE
fix(inovmicro-exao): bloc REPL en python plutôt qu'en pycon

### DIFF
--- a/site/docs/inovmicro-exao/i03-decouverte-thonny.md
+++ b/site/docs/inovmicro-exao/i03-decouverte-thonny.md
@@ -293,7 +293,7 @@ Le **REPL** (`>>>` dans le panneau Shell) permet de tester du code **directement
 
 Dans l'exemple ci-dessous, les `>>>` représentent le prompt — c'est ce que Thonny affiche pour signaler qu'il attend une commande. Ne pas les recopier dans l'éditeur, tapez uniquement ce qui suit le prompt.
 
-```pycon
+```python
 # Allumer la LED rouge à la main
 >>> from machine import Pin
 >>> led_r = Pin('LED_RED', Pin.OUT)


### PR DESCRIPTION
## Résumé

Sur la PR #78 fraîchement mergée, j'avais passé le bloc REPL de la fiche i03 Thonny de \`\`\`python à \`\`\`pycon (suggestion Copilot pour qu'un éditeur reconnaisse les prompts). Mais après vérification :

- \`pycon\` n'est pas dans les \`additionalLanguages\` de [\`site/docusaurus.config.ts\`](../blob/main/site/docusaurus.config.ts)
- c'est le seul usage de \`pycon\` dans tout le site

Conséquence : Prism tombait en plain text au lieu de colorer. Je reviens à \`\`\`python qui highlight au moins les imports et keywords. La phrase d'avertissement *« les >>> sont le prompt, ne pas les recopier »* reste — c'est elle qui fait le vrai travail pédagogique.

## Type de changement

- [x] Contenu — fiche, doc, texte
- [ ] Configuration

## Test plan

- [x] Format / lint OK
- [x] Build CI vert

## Alternative possible (hors scope)

Si on veut vraiment \`pycon\`, il faudrait ajouter \`additionalLanguages: ['pycon']\` dans la config Prism (\`site/docusaurus.config.ts\`). À faire dans une issue séparée si l'usage devient courant.