### PR TITLE
fix(inovmicro-exao): summary i13 (PWM trompeur) + dédoublonnage cspell

### DIFF
--- a/.cspell/wikilab.txt
+++ b/.cspell/wikilab.txt
@@ -168,12 +168,9 @@ pinout
 thonny
 APDS
 apds9960
-breadboard
 lumiere
 piézo
 piezo
-buzzer
-Morse
 morse
 
 # Magnetics — projet Edu-up (BLE Mesh micro:bit / STM32 / MicroPython)

--- a/site/src/data/resources.ts
+++ b/site/src/data/resources.ts
@@ -3741,7 +3741,7 @@ export const resources: Resource[] = [
     slug: '/ressources/inovmicro-exao/i13-morse',
     project: 'inovmicro-exao',
     summary:
-      'Programmer un émetteur Morse avec le buzzer piézo intégré et les boutons A et B de la STeaMi. Découverte du PWM, du codage à longueur variable et envoi de messages en code Morse international.',
+      "Programmer un émetteur Morse avec le buzzer piézo intégré et les boutons A et B de la STeaMi. Génération d'une fréquence audio par bascule rapide d'une broche, codage à longueur variable et envoi de messages en code Morse international.",
     disciplines: ['informatique', 'technologie'],
     tools: ['steami'],
     software: ['python'],

--- a/site/src/data/resources.ts
+++ b/site/src/data/resources.ts
@@ -3751,7 +3751,7 @@ export const resources: Resource[] = [
     difficulty: 'avance',
     formats: ['programmation', 'experimentation'],
     categories: ['programmation'],
-    keywords: ['STeaMi', 'MicroPython', 'Morse', 'PWM', 'buzzer', 'piézo', 'codage'],
+    keywords: ['STeaMi', 'MicroPython', 'Morse', 'buzzer', 'piézo', 'codage'],
     thumbnail: '/img/ressources/inovmicro-exao/i13-code-morse/icone.png',
   },
   {


### PR DESCRIPTION
## Résumé

Deux retours de Copilot arrivés sur la PR #72 [après son merge](https://github.com/LabAixBidouille/wikilab/pull/72#issuecomment-4429203340), traités ici.

1. **Summary `i13-morse` trompeur** ([resources.ts:3745](https://github.com/LabAixBidouille/wikilab/pull/72#discussion_r3225379360)) : le `summary` mentionne *« Découverte du PWM »* alors que la fiche fait du **bit-banging** (alternance `pin.on()` / `pin.off()` depuis le programme), pas du PWM hardware. Reformulé en *« Génération d'une fréquence audio par bascule rapide d'une broche »* — plus fidèle à ce que la fiche apprend réellement.

2. **Doublons dans `.cspell/wikilab.txt`** ([cspell:177](https://github.com/LabAixBidouille/wikilab/pull/72#discussion_r3225379406)) : `buzzer` et `breadboard` étaient présents deux fois (section originale + section ajoutée au fil des reviews récentes). Au passage, retiré aussi le doublon `Morse` / `morse` puisque cspell est case-insensitive par défaut.

## Type de changement

- [x] Contenu — fiche, doc, texte (summary catalogue)
- [x] Configuration (cspell dico)

## Test plan

- [x] `npm run format:check` passe
- [x] `npm run lint:md` passe
- [x] `npm run lint:spell` passe
- [x] Plus de doublons dans le dictionnaire : `sort .cspell/wikilab.txt | grep -v '^#\|^$' | uniq -d` retourne vide