### PR TITLE
docs(conventions): consolider 5 conventions stabilisées au fil des reviews

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ projets/unplugged/Unplugged_Equal_FR.pdf
 *.mp4
 *.mov
 *.webm
+
+# Claude Code working artifacts
+.claude/

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -19,7 +19,7 @@ Ce document fait autorité pour le **formatage des fiches pédagogiques** et leu
 10. [Sous-pages (borne-arcade, programmation)](#sous-pages-borne-arcade-programmation)
 11. [Fiches de programmation extraites](#fiches-de-programmation-extraites)
 12. [Code MicroPython sur STeaMi](#code-micropython-sur-steami)
-13. [Fiches éditeur-agnostiques](#fiches-éditeur-agnostiques)
+13. [Fiches indépendantes de l'éditeur](#fiches-indépendantes-de-léditeur)
 14. [Couleurs des projets](#couleurs-des-projets)
 
 ## Header (en-tête de fiche)
@@ -157,7 +157,7 @@ Pour repérer les occurrences dans une fiche :
 grep -n "—\|–\|…" site/docs/<projet>/<fiche>.md
 ```
 
-**Autorisés** : les **symboles scientifiques et techniques** (`Ω` pour les Ohms, `°C` pour les degrés, `≈` pour les approximations, `∥` pour le parallèle en électricité, `µ` pour micro), les **flèches** (`→`, `↑`, `↓`, `←`) quand elles structurent visuellement une explication, et les **émojis** avec parcimonie. Ces caractères apportent une valeur sémantique ou pédagogique qui justifie le copier-coller au moment où on en a besoin.
+**Autorisés** : les **symboles scientifiques et techniques** (`Ω` pour les Ohms, `°C` pour les degrés, `≈` pour les approximations, `∥` pour le parallèle en électricité, `µ` pour micro), les **flèches** (`→`, `↑`, `↓`, `←`) quand elles structurent visuellement une explication, les **icônes UI** quand elles reproduisent un bouton de l'interface (`▶` pour Run, etc.), le **point médian `·`** de l'écriture inclusive (`enseignant·e`, `élève·s`), et les **émojis** avec parcimonie. Ces caractères apportent une valeur sémantique ou pédagogique qui justifie le copier-coller au moment où on en a besoin.
 
 **Apostrophes typographiques** : tolérées. La plupart des éditeurs font l'auto-substitution `'` (ASCII U+0027) en `'` (typographique U+2019) sans intervention. Si vous préférez forcer l'apostrophe droite ASCII, c'est aussi accepté ; la cohérence à l'intérieur d'une fiche compte plus que le choix.
 
@@ -345,7 +345,7 @@ Les sessions REPL avec prompts `>>>` doivent être précédées d'un avertisseme
 
 Garder la fence ` ```python ` (pas `pycon`, qui n'est pas dans les `additionalLanguages` de la config Prism du site).
 
-## Fiches éditeur-agnostiques
+## Fiches indépendantes de l'éditeur
 
 Les fiches de **capteur / actionneur / activité** ne doivent pas être liées à un éditeur Python spécifique. Seules les fiches de prise en main des éditeurs eux-mêmes (i01 à i05 du projet I-Novmicro #2 : éditeur web STeaMi, Mu, Thonny, VS Code, Vittascience) sont éditeur-spécifiques. Toutes les autres fiches sont écrites de façon à fonctionner avec n'importe quel IDE compatible MicroPython.
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -117,8 +117,8 @@ Couleurs et icônes : voir [`site/src/css/custom.css`](site/src/css/custom.css) 
 Préférer aussi l'infinitif ou les tournures impersonnelles quand le contexte s'y prête (instructions techniques, étapes à suivre), ce qui évite la question du registre :
 
 - _« Brancher la carte à l'ordinateur. »_ (infinitif)
-- _« On peut vérifier dans le REPL que… »_ (impersonnel)
-- _« Si vous utilisez Linux… »_ (vouvoiement quand on s'adresse directement)
+- _« On peut vérifier dans le REPL que... »_ (impersonnel)
+- _« Si vous utilisez Linux... »_ (vouvoiement quand on s'adresse directement)
 
 ### Vocabulaire
 
@@ -135,7 +135,7 @@ Préférer aussi l'infinitif ou les tournures impersonnelles quand le contexte s
 
 Quand un concept technique est central mais opaque pour la cible, introduire une **métaphore** avant le terme technique, jamais l'inverse. Exemples installés dans le wiki :
 
-- **Framebuffer** : _« On peut imaginer l'écran de la STeaMi comme un tableau noir caché derrière un voile. Les fonctions text(), clear()… dessinent sur le tableau, mais le voile reste en place tant qu'on n'a pas appelé `screen.show()`. À ce moment-là, le voile tombe et tout ce qu'on a dessiné apparaît d'un coup. »_
+- **Framebuffer** : _« On peut imaginer l'écran de la STeaMi comme un tableau noir caché derrière un voile. Les fonctions text(), clear()... dessinent sur le tableau, mais le voile reste en place tant qu'on n'a pas appelé `screen.show()`. À ce moment-là, le voile tombe et tout ce qu'on a dessiné apparaît d'un coup. »_
 - **REPL** : _« une fenêtre de dialogue où l'on tape une instruction et la carte y répond immédiatement »_
 - **DAPLink** : _« la STeaMi est livrée avec un mode "clé USB" préinstallé »_ (le nom DAPLink lui-même n'a pas besoin d'apparaître).
 
@@ -143,7 +143,7 @@ Le principe : **on part de ce que voit l'élève, on introduit le mot technique 
 
 ### Caractères à éviter
 
-**Ne pas utiliser de caractères Unicode qui ne sont pas directement accessibles sur un clavier AZERTY standard**. Ces caractères créent une friction d'édition (impossibles à taper directement) et, dans le cas du _em-dash_ notamment, sont aujourd'hui perçus comme un signal de texte généré par IA, ce qu'on veut explicitement éviter sur un wiki pédagogique.
+**Ne pas utiliser de caractères de ponctuation typographique** (em-dash, en-dash, ellipsis Unicode). Ces caractères créent une friction d'édition (impossibles à taper directement sur AZERTY standard) et, dans le cas du _em-dash_ notamment, sont aujourd'hui perçus comme un signal de texte généré par IA, ce qu'on veut explicitement éviter sur un wiki pédagogique.
 
 | À éviter     | Pourquoi                         | À utiliser à la place                  |
 | ------------ | -------------------------------- | -------------------------------------- |
@@ -157,7 +157,9 @@ Pour repérer les occurrences dans une fiche :
 grep -n "—\|–\|…" site/docs/<projet>/<fiche>.md
 ```
 
-**Exception** : les **émojis** restent autorisés mais avec parcimonie (copier-coller au moment où on en a besoin). Les apostrophes typographiques `'` sont également tolérées (la plupart des éditeurs font l'auto-substitution `'` → `'`, donc pas de friction réelle).
+**Autorisés** : les **symboles scientifiques et techniques** (`Ω` pour les Ohms, `°C` pour les degrés, `≈` pour les approximations, `∥` pour le parallèle en électricité, `µ` pour micro), les **flèches** (`→`, `↑`, `↓`, `←`) quand elles structurent visuellement une explication, et les **émojis** avec parcimonie. Ces caractères apportent une valeur sémantique ou pédagogique qui justifie le copier-coller au moment où on en a besoin.
+
+**Apostrophes typographiques** : tolérées. La plupart des éditeurs font l'auto-substitution `'` (ASCII U+0027) en `'` (typographique U+2019) sans intervention. Si vous préférez forcer l'apostrophe droite ASCII, c'est aussi accepté ; la cohérence à l'intérieur d'une fiche compte plus que le choix.
 
 **Exception temporaire** : le nom du projet `I-Novmicro #2 — Action EXAO` contient un em-dash et est référencé tel quel dans les footers des fiches portées et dans `site/src/data/projects.ts`. Le renommage est tracé dans l'[issue #84](https://github.com/LabAixBidouille/wikilab/issues/84) et sera propagé partout en une seule fois.
 
@@ -345,7 +347,7 @@ Garder la fence ` ```python ` (pas `pycon`, qui n'est pas dans les `additionalLa
 
 ## Fiches éditeur-agnostiques
 
-Les fiches de **capteur / actionneur / activité** ne doivent pas être liées à un éditeur Python spécifique. Seules les fiches de prise en main des éditeurs eux-mêmes (i01–i05 du projet I-Novmicro #2 : éditeur web STeaMi, Mu, Thonny, VS Code, Vittascience) sont éditeur-spécifiques. Toutes les autres fiches sont écrites de façon à fonctionner avec n'importe quel IDE compatible MicroPython.
+Les fiches de **capteur / actionneur / activité** ne doivent pas être liées à un éditeur Python spécifique. Seules les fiches de prise en main des éditeurs eux-mêmes (i01 à i05 du projet I-Novmicro #2 : éditeur web STeaMi, Mu, Thonny, VS Code, Vittascience) sont éditeur-spécifiques. Toutes les autres fiches sont écrites de façon à fonctionner avec n'importe quel IDE compatible MicroPython.
 
 Patterns à adopter :
 
@@ -359,10 +361,10 @@ Si une fonctionnalité spécifique à un éditeur mérite d'être mentionnée (p
 
 ### Une fiche STeaMi se suffit à elle-même
 
-Pour les fiches portées depuis Let's STEAM (slugs `i08`–`i22`), **rédiger la fiche STeaMi comme si Let's STEAM n'existait pas** :
+Pour les fiches portées depuis Let's STEAM (slugs `i08` à `i22`), **rédiger la fiche STeaMi comme si Let's STEAM n'existait pas** :
 
-- Pas de comparaison à la fiche d'origine dans le corps (_« contrairement à la fiche Let's STEAM qui demandait… »_, _« on passe des blocs MakeCode à des fonctions Python »_, etc.).
-- Pas de mention de l'éditeur d'origine (MakeCode) ni du matériel d'origine (Adafruit, breadboard externe…).
+- Pas de comparaison à la fiche d'origine dans le corps (_« contrairement à la fiche Let's STEAM qui demandait... »_, _« on passe des blocs MakeCode à des fonctions Python »_, etc.).
+- Pas de mention de l'éditeur d'origine (MakeCode) ni du matériel d'origine (Adafruit, breadboard externe...).
 - Le lecteur·rice n'a pas besoin de connaître la fiche d'origine pour comprendre.
 
 L'**attribution CC BY-SA 4.0** reste obligatoire **dans le footer** :

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -159,7 +159,7 @@ grep -n "—\|–\|…" site/docs/<projet>/<fiche>.md
 
 **Autorisés** : les **symboles scientifiques et techniques** (`Ω` pour les Ohms, `°C` pour les degrés, `≈` pour les approximations, `∥` pour le parallèle en électricité, `µ` pour micro), les **flèches** (`→`, `↑`, `↓`, `←`) quand elles structurent visuellement une explication, les **icônes UI** quand elles reproduisent un bouton de l'interface (`▶` pour Run, etc.), le **point médian `·`** de l'écriture inclusive (`enseignant·e`, `élève·s`), et les **émojis** avec parcimonie. Ces caractères apportent une valeur sémantique ou pédagogique qui justifie le copier-coller au moment où on en a besoin.
 
-**Apostrophes typographiques** : tolérées. La plupart des éditeurs font l'auto-substitution `'` (ASCII U+0027) en `'` (typographique U+2019) sans intervention. Si vous préférez forcer l'apostrophe droite ASCII, c'est aussi accepté ; la cohérence à l'intérieur d'une fiche compte plus que le choix.
+**Apostrophes typographiques** : tolérées. La plupart des éditeurs font l'auto-substitution `'` (ASCII U+0027) en `’` (typographique U+2019) sans intervention. Si vous préférez forcer l'apostrophe droite ASCII, c'est aussi accepté ; la cohérence à l'intérieur d'une fiche compte plus que le choix.
 
 **Exception temporaire** : le nom du projet `I-Novmicro #2 — Action EXAO` contient un em-dash et est référencé tel quel dans les footers des fiches portées et dans `site/src/data/projects.ts`. Le renommage est tracé dans l'[issue #84](https://github.com/LabAixBidouille/wikilab/issues/84) et sera propagé partout en une seule fois.
 
@@ -270,7 +270,7 @@ from machine import Pin
 # ...
 ```
 
-(Le mot _firmware_ est toléré ici dans un commentaire de code parce qu'il s'adresse au·à la contributeur·rice qui modifie le code, pas au lecteur·rice de la fiche.)
+(Le mot _firmware_ est toléré ici dans un commentaire de code parce qu'il s'adresse aux personnes qui modifient le code, pas à celles qui lisent la fiche.)
 
 ### Noms de broches parlants
 
@@ -365,7 +365,7 @@ Pour les fiches portées depuis Let's STEAM (slugs `i08` à `i22`), **rédiger l
 
 - Pas de comparaison à la fiche d'origine dans le corps (_« contrairement à la fiche Let's STEAM qui demandait... »_, _« on passe des blocs MakeCode à des fonctions Python »_, etc.).
 - Pas de mention de l'éditeur d'origine (MakeCode) ni du matériel d'origine (Adafruit, breadboard externe...).
-- Le lecteur·rice n'a pas besoin de connaître la fiche d'origine pour comprendre.
+- La personne qui lit la fiche n'a pas besoin de connaître la fiche d'origine pour comprendre.
 
 L'**attribution CC BY-SA 4.0** reste obligatoire **dans le footer** :
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -1,4 +1,4 @@
-# Conventions de contenu — Wiki@LAB
+# Conventions de contenu Wiki@LAB
 
 Ce document fait autorité pour le **formatage des fiches pédagogiques** et leur intégration au catalogue. Tout contributeur de contenu doit s'y référer.
 
@@ -18,7 +18,9 @@ Ce document fait autorité pour le **formatage des fiches pédagogiques** et leu
 9. [Suivi photos](#suivi-photos)
 10. [Sous-pages (borne-arcade, programmation)](#sous-pages-borne-arcade-programmation)
 11. [Fiches de programmation extraites](#fiches-de-programmation-extraites)
-12. [Couleurs des projets](#couleurs-des-projets)
+12. [Code MicroPython sur STeaMi](#code-micropython-sur-steami)
+13. [Fiches éditeur-agnostiques](#fiches-éditeur-agnostiques)
+14. [Couleurs des projets](#couleurs-des-projets)
 
 ## Header (en-tête de fiche)
 
@@ -60,7 +62,7 @@ Couleurs et icônes : voir [`site/src/css/custom.css`](site/src/css/custom.css) 
 ### Règles
 
 - Ne JAMAIS utiliser `:::tip` pour des conseils non-imprimables
-- Le titre par défaut est posé par le composant — surcharger avec `:::question[Mon titre]` si besoin
+- Le titre par défaut est posé par le composant : surcharger avec `:::question[Mon titre]` si besoin
 - Pour ajouter un nouveau type custom : 1) déclarer le keyword dans `docusaurus.config.ts`, 2) créer le composant dans `site/src/theme/Admonition/Type/`, 3) référencer dans `site/src/theme/Admonition/Types.tsx`, 4) ajouter le CSS dans `custom.css`
 
 ## Images
@@ -79,7 +81,7 @@ Couleurs et icônes : voir [`site/src/css/custom.css`](site/src/css/custom.css) 
 
   NE JAMAIS laisser une image avec figcaption alignée à gauche.
 
-- **Images côte à côte sans étirement** : flex container avec `alignItems: 'flex-start'` et chaque image en `maxWidth: 'calc(50% - 1rem)'` + `height: 'auto'` + `alignSelf: 'flex-start'` (préserve les proportions naturelles, espace vide sous la plus petite si tailles différentes — c'est OK)
+- **Images côte à côte sans étirement** : flex container avec `alignItems: 'flex-start'` et chaque image en `maxWidth: 'calc(50% - 1rem)'` + `height: 'auto'` + `alignSelf: 'flex-start'` (préserve les proportions naturelles, espace vide sous la plus petite si tailles différentes, c'est OK)
 
   ```jsx
   <div style={{ display: 'flex', gap: '2rem', alignItems: 'flex-start', flexWrap: 'wrap' }}>
@@ -98,6 +100,8 @@ Couleurs et icônes : voir [`site/src/css/custom.css`](site/src/css/custom.css) 
 
 ## Texte
 
+### Mise en forme
+
 - Justifié (CSS global)
 - Titres numérotés de manière homogène (Partie 1, 2, 3...)
 - Pas de bold dans les headings
@@ -105,6 +109,57 @@ Couleurs et icônes : voir [`site/src/css/custom.css`](site/src/css/custom.css) 
 - Listes avec deux-points → premier élément en gras : `- **Label** : description`
 - Footer Erasmus+ en bas de chaque fiche concernée
 - Gras pour : "Contexte de la séquence" et "Objectifs d'apprentissage"
+
+### Registre
+
+**Vouvoiement** (_« vous »_) dans toute la fiche, pas de tutoiement. Ce choix laisse à l'enseignant·e le choix du registre à utiliser avec sa classe : une fiche tutoyante imposerait le tutoiement à toute la classe ; une fiche vouvoyante peut être lue puis reformulée par l'enseignant·e.
+
+Préférer aussi l'infinitif ou les tournures impersonnelles quand le contexte s'y prête (instructions techniques, étapes à suivre), ce qui évite la question du registre :
+
+- _« Brancher la carte à l'ordinateur. »_ (infinitif)
+- _« On peut vérifier dans le REPL que… »_ (impersonnel)
+- _« Si vous utilisez Linux… »_ (vouvoiement quand on s'adresse directement)
+
+### Vocabulaire
+
+**Principe général** : vocabulaire le moins technique possible. Chaque terme technique conservé est glosé à sa première mention, par exemple _« MicroPython, une version de Python adaptée aux cartes électroniques »_ à la première occurrence dans la fiche.
+
+**À éviter** :
+
+- _« firmware »_ : utiliser _« MicroPython »_ directement, ou _« le programme installé sur la carte »_, ou _« le logiciel embarqué »_.
+- Les superlatifs vides (_« très puissant »_, _« atout fort »_, _« simplifie radicalement »_) : remplacer par une description factuelle de ce que la fonctionnalité fait.
+- Le registre familier (_« beaucoup de soucis »_, _« toute seule »_) : neutraliser.
+- _« chaîne de compilation »_, _« liaison série »_ : préférer respectivement _« plusieurs logiciels à installer »_ et _« communication entre l'éditeur et la carte »_.
+
+### Métaphores plutôt que jargon
+
+Quand un concept technique est central mais opaque pour la cible, introduire une **métaphore** avant le terme technique, jamais l'inverse. Exemples installés dans le wiki :
+
+- **Framebuffer** : _« On peut imaginer l'écran de la STeaMi comme un tableau noir caché derrière un voile. Les fonctions text(), clear()… dessinent sur le tableau, mais le voile reste en place tant qu'on n'a pas appelé `screen.show()`. À ce moment-là, le voile tombe et tout ce qu'on a dessiné apparaît d'un coup. »_
+- **REPL** : _« une fenêtre de dialogue où l'on tape une instruction et la carte y répond immédiatement »_
+- **DAPLink** : _« la STeaMi est livrée avec un mode "clé USB" préinstallé »_ (le nom DAPLink lui-même n'a pas besoin d'apparaître).
+
+Le principe : **on part de ce que voit l'élève, on introduit le mot technique après pour le nommer**, jamais avant.
+
+### Caractères à éviter
+
+**Ne pas utiliser de caractères Unicode qui ne sont pas directement accessibles sur un clavier AZERTY standard**. Ces caractères créent une friction d'édition (impossibles à taper directement) et, dans le cas du _em-dash_ notamment, sont aujourd'hui perçus comme un signal de texte généré par IA, ce qu'on veut explicitement éviter sur un wiki pédagogique.
+
+| À éviter     | Pourquoi                         | À utiliser à la place                  |
+| ------------ | -------------------------------- | -------------------------------------- |
+| em-dash `—`  | non accessible clavier, perçu IA | `:`, `.`, `-` ou `,` selon le contexte |
+| en-dash `–`  | idem                             | tiret simple `-`                       |
+| ellipses `…` | idem                             | `...` (trois points)                   |
+
+Pour repérer les occurrences dans une fiche :
+
+```bash
+grep -n "—\|–\|…" site/docs/<projet>/<fiche>.md
+```
+
+**Exception** : les **émojis** restent autorisés mais avec parcimonie (copier-coller au moment où on en a besoin). Les apostrophes typographiques `'` sont également tolérées (la plupart des éditeurs font l'auto-substitution `'` → `'`, donc pas de friction réelle).
+
+**Exception temporaire** : le nom du projet `I-Novmicro #2 — Action EXAO` contient un em-dash et est référencé tel quel dans les footers des fiches portées et dans `site/src/data/projects.ts`. Le renommage est tracé dans l'[issue #84](https://github.com/LabAixBidouille/wikilab/issues/84) et sera propagé partout en une seule fois.
 
 ## Contenu à supprimer
 
@@ -134,7 +189,7 @@ Chaque fiche est une entrée avec :
 - `summary` (1-2 phrases)
 - `disciplines`, `tools`, `software` (unions de types stricts)
 - `ageMin`, `ageMax` (entiers)
-- `durationMinutes` (max 240 — au-delà la fiche est trop longue)
+- `durationMinutes` (max 240, au-delà la fiche est trop longue)
 - `difficulty` (`debutant` | `intermediaire` | `avance`)
 - `formats` (un ou plusieurs parmi `debranchee`, `programmation`, `experimentation`, `jeu-de-role`, `bricolage`, `enquete`, `projet-maker`)
 - `categories` : 11 approches pédagogiques, multi-catégories autorisées :
@@ -177,6 +232,144 @@ Les fiches longues (SteamCity, TheDexterLab) qui contiennent des sections de pro
 Dans la fiche principale, remplacer la section extraite par un lien `## Programmation` pointant vers la fiche technique.
 
 Les tableaux vides (exemples à remplir) doivent avoir des lignes de taille égale (même nombre de cellules).
+
+## Code MicroPython sur STeaMi
+
+Conventions stabilisées au fil des premières fiches du projet [I-Novmicro #2 — Action EXAO](https://github.com/LabAixBidouille/wikilab/issues/2). À appliquer à toutes les fiches qui contiennent du code MicroPython pour la carte STeaMi.
+
+### Tableau du header
+
+Cinq colonnes : `| Projet | Durée | Difficulté | Âge | Logiciel STeaMi testé |`.
+
+```md
+| Projet        | Durée  | Difficulté | Âge       | Logiciel STeaMi testé |
+| ------------- | ------ | ---------- | --------- | --------------------- |
+| I-Novmicro #2 | 35 min | Débutant   | 11-99 ans | 0.23.1                |
+```
+
+La colonne _Logiciel STeaMi testé_ contient le numéro de version du fichier `steami-micropython-firmware-vX.Y.Z.hex` téléchargé depuis [les releases du firmware](https://github.com/steamicc/micropython-steami-lib/releases). Le label _« Logiciel STeaMi »_ évite _« firmware »_ (banni du vocabulaire des fiches, cf. [Vocabulaire](#vocabulaire)), _« MicroPython »_ (qui prêterait à confusion avec le `v1.XX.X` upstream affiché dans le prompt du REPL), et _« Version STeaMi »_ (qui prêterait à confusion avec la version matérielle V1 micro-USB / V2 USB-C).
+
+### Câble USB dans la liste matériel
+
+Deux versions de la carte cohabitent dans les classes (V1 micro-USB, V2 USB-C). Couvrir les deux :
+
+```md
+- 1 câble USB de données (micro-USB pour la STeaMi V1, USB-C pour la STeaMi V2). Attention : un câble qui ne sert qu'à charger un téléphone ne fonctionnera pas.
+```
+
+### Version du firmware en commentaire du code
+
+Chaque bloc de code MicroPython commence par un commentaire qui annonce la version du logiciel STeaMi avec laquelle le code a été testé :
+
+```python
+# Testée avec firmware STeaMi 0.23.1
+#
+from machine import Pin
+# ...
+```
+
+(Le mot _firmware_ est toléré ici dans un commentaire de code parce qu'il s'adresse au·à la contributeur·rice qui modifie le code, pas au lecteur·rice de la fiche.)
+
+### Noms de broches parlants
+
+Utiliser les alias exposés par le firmware MicroPython STeaMi, pas la nomenclature interne STMicroelectronics (`PC12`, `PA7`...). Référence : [wiki STeaMi, page signals](https://wiki.steami.cc/docs/hardware/pin-mapping/signals).
+
+Quelques noms parlants courants :
+
+| Composant            | Alias                                               |
+| -------------------- | --------------------------------------------------- |
+| LED RGB utilisateur  | `LED_RED`, `LED_GREEN`, `LED_BLUE`                  |
+| Boutons GPIO directs | `A_BUTTON`, `B_BUTTON`, `MENU_BUTTON`               |
+| Écran OLED (SPI)     | `DATA_COMMAND_DISPLAY`, `RST_DISPLAY`, `CS_DISPLAY` |
+| Buzzer / Speaker     | `SPEAKER`                                           |
+
+Pour les **boutons directionnels** (`UP_BUTTON`, `DOWN_BUTTON`, `LEFT_BUTTON`, `RIGHT_BUTTON`), attention : ils passent par un expandeur GPIO (`MCP23009`) sur le bus I2C interne, **pas** par des broches directes. Ils ne se lisent donc pas avec `Pin('UP_BUTTON', Pin.IN)` mais via le driver `mcp23009e` du repo `micropython-steami-lib`.
+
+### Boutons : pas de `Pin.PULL_UP`
+
+Les boutons utilisateurs ont des **résistances pull-up externes** (4,7 kΩ) câblées sur la carte. Ne pas activer la pull-up interne dans le code :
+
+```python
+btn_a = Pin('A_BUTTON', Pin.IN)              # ← correct
+btn_a = Pin('A_BUTTON', Pin.IN, Pin.PULL_UP) # ← redondant, à éviter
+```
+
+Activer la pull-up interne en plus est inutile électriquement (40 kΩ ∥ 4,7 kΩ ≈ 4,2 kΩ, négligeable) et pédagogiquement contre-productif : ça suggère qu'il faut la pull-up dans le code alors que la pull-up est physique.
+
+### Logique LED : normale
+
+Les LEDs utilisateurs (RGB sur PC10/PC11/PC12) sont en logique **normale** : `value(1)` allume, `value(0)` éteint, `.on()` et `.off()` font ce qu'on attend. **Ne pas écrire** _« active basse »_, c'est faux selon les tests officiels du firmware.
+
+### `sleep_ms` plutôt que `sleep()`
+
+Utiliser `sleep_ms` (millisecondes entières) plutôt que `sleep` (secondes flottantes) :
+
+```python
+from time import sleep_ms
+sleep_ms(100)    # idiome MicroPython, économe en RAM
+```
+
+Plutôt que :
+
+```python
+from time import sleep
+sleep(0.1)       # style CPython, à éviter
+```
+
+### Bloc d'initialisation factorisé
+
+Quand plusieurs blocs de code se suivent dans une même fiche (par exemple un programme principal en Étape 2 puis plusieurs défis en Étape 3), factoriser le bloc d'initialisation en début de section et y faire référence depuis les suivants. Exemple sur la fiche écran OLED ([i17-texte-oled](site/docs/inovmicro-exao/i17-texte-oled.md)) :
+
+```python
+# Bloc d'initialisation commun à tous les défis ci-dessous.
+import ssd1327
+from machine import SPI, Pin
+from steami_screen import Screen, SSD1327Display
+
+spi = SPI(1)
+dc  = Pin("DATA_COMMAND_DISPLAY")
+res = Pin("RST_DISPLAY")
+cs  = Pin("CS_DISPLAY")
+raw     = ssd1327.WS_OLED_128X128_SPI(spi, dc, res, cs)
+display = SSD1327Display(raw)
+screen  = Screen(display)
+```
+
+### Bloc REPL avec avertissement sur `>>>`
+
+Les sessions REPL avec prompts `>>>` doivent être précédées d'un avertissement explicite pour la cible élève, qui sinon recopie les chevrons dans l'éditeur :
+
+> _« Les `>>>` ci-dessous sont le prompt affiché par MicroPython dans la console pour indiquer qu'il attend une commande, ne les tapez pas, écrivez seulement ce qui suit. »_
+
+Garder la fence ` ```python ` (pas `pycon`, qui n'est pas dans les `additionalLanguages` de la config Prism du site).
+
+## Fiches éditeur-agnostiques
+
+Les fiches de **capteur / actionneur / activité** ne doivent pas être liées à un éditeur Python spécifique. Seules les fiches de prise en main des éditeurs eux-mêmes (i01–i05 du projet I-Novmicro #2 : éditeur web STeaMi, Mu, Thonny, VS Code, Vittascience) sont éditeur-spécifiques. Toutes les autres fiches sont écrites de façon à fonctionner avec n'importe quel IDE compatible MicroPython.
+
+Patterns à adopter :
+
+| À éviter                                     | À préférer                                                                                                                                                                                                                    |
+| -------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| _« Thonny installé »_ dans la liste matériel | _« Un IDE MicroPython installé. Voir la fiche [Thonny : prise en main de MicroPython](/ressources/inovmicro-exao/i03-decouverte-thonny) pour la mise en place, tout autre éditeur compatible MicroPython fonctionne aussi. »_ |
+| _« le panneau Shell de Thonny »_             | _« la console MicroPython »_                                                                                                                                                                                                  |
+| _« bouton Run (▶) ou F5 »_ (sans précision)  | _« lancer le programme depuis votre IDE (typiquement bouton Run ▶ ou F5) »_                                                                                                                                                   |
+
+Si une fonctionnalité spécifique à un éditeur mérite d'être mentionnée (par exemple le Plotter de Thonny dans la fiche capteur de lumière), l'encadrer dans un callout dont le titre dit explicitement _« (spécifique à Thonny) »_.
+
+### Une fiche STeaMi se suffit à elle-même
+
+Pour les fiches portées depuis Let's STEAM (slugs `i08`–`i22`), **rédiger la fiche STeaMi comme si Let's STEAM n'existait pas** :
+
+- Pas de comparaison à la fiche d'origine dans le corps (_« contrairement à la fiche Let's STEAM qui demandait… »_, _« on passe des blocs MakeCode à des fonctions Python »_, etc.).
+- Pas de mention de l'éditeur d'origine (MakeCode) ni du matériel d'origine (Adafruit, breadboard externe…).
+- Le lecteur·rice n'a pas besoin de connaître la fiche d'origine pour comprendre.
+
+L'**attribution CC BY-SA 4.0** reste obligatoire **dans le footer** :
+
+```md
+_Cette fiche fait partie du projet [I-Novmicro #2 — Action EXAO](/projets/inovmicro-exao). Adaptée du projet [Let's STEAM](/projets/lets-steam) (fiche [`r1asXX-nom`](/ressources/lets-steam/r1asXX-nom)) sous licence [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/deed.fr)._
+```
 
 ## Couleurs des projets
 


### PR DESCRIPTION
## Résumé

Cette PR rapatrie dans [`CONVENTIONS.md`](../blob/main/CONVENTIONS.md) les conventions qu'on a posées itérativement au fil des reviews des fiches I-Novmicro #2 (PR #66 Thonny, #67 OLED, #70 capteur de lumière, #72 code Morse, et les fix associés). Elles existaient de fait dans le wiki mais n'étaient écrites nulle part, donc invisibles aux contributeurs·rices qui n'ont pas suivi les reviews précédentes.

**Issues adressées** : #74, #76, #81 (partie doc), #82, #84 (partie doc).

## Détail des ajouts

### 1. Section "Texte" complétée

- **Registre** : vouvoiement par défaut (#74).
- **Vocabulaire** : principe général, mots à éviter (*firmware*, superlatifs vides, registre familier, *chaîne de compilation*, *liaison série*).
- **Métaphores plutôt que jargon** : framebuffer, REPL, DAPLink, comme exemples installés dans les fiches existantes.
- **Caractères à éviter** (#84) : pas d'em-dash, en-dash, ellipses Unicode. Tableau des remplacements. Commande grep pour détecter. Exception temporaire documentée pour le nom du projet *« I-Novmicro #2 — Action EXAO »* qui sera renommé via l'issue #84.

### 2. Nouvelle section "Code MicroPython sur STeaMi" (#76 + #81 doc)

- Tableau header à 5 colonnes avec *« Logiciel STeaMi testé »* et l'argumentaire (pourquoi ce label précis : pas *firmware*, pas *MicroPython* à cause du v1.XX.X du REPL, pas *Version STeaMi* à cause de la version matérielle).
- Câble USB V1/V2 dans la liste matériel.
- Commentaire firmware en première ligne du code.
- Noms de broches parlants (`LED_RED`, `A_BUTTON`, `DATA_COMMAND_DISPLAY`...) plutôt que `PC12`/`PA7`. Note sur les boutons directionnels qui passent par l'expandeur MCP23009.
- Pas de `Pin.PULL_UP` (les boutons ont une pull-up externe physique sur la carte).
- LEDs en logique normale (`value(1)` = allumée).
- `sleep_ms` plutôt que `sleep()`.
- Pattern de bloc d'initialisation factorisé.
- Avertissement `>>>` obligatoire avant les blocs REPL, fence `python` (pas `pycon` qui n'est pas configuré dans Prism).

### 3. Nouvelle section "Fiches éditeur-agnostiques" (#82)

- Les fiches de capteur/actionneur/activité ne doivent pas être liées à un éditeur. Seules les fiches i01-i05 (prise en main des éditeurs) sont éditeur-spécifiques.
- Tableau des patterns à adopter (avant/après) : remplacements pour *« Thonny installé »*, *« panneau Shell de Thonny »*, *« bouton Run ▶ »*.
- Sous-section *« Une fiche STeaMi se suffit à elle-même »* : principe de ne pas comparer aux fiches Let's STEAM d'origine dans le corps, attribution CC BY-SA reste dans le footer.

### Sommaire mis à jour

Avec les deux nouvelles sections.

## Note méta

J'ai dû appliquer la règle *« pas d'em-dash »* à ce document lui-même pendant la rédaction (8 occurrences ironiquement introduites, remplacées par `:` ou `,`). Les 5 occurrences qui restent dans `CONVENTIONS.md` sont **légitimes** :

- 2 dans l'illustration de la règle elle-même (caractère affiché + commande grep)
- 3 dans les références au nom du projet *« I-Novmicro #2 — Action EXAO »*, sous l'exception temporaire documentée (à fixer via l'issue #84 quand on renommera le projet).

Ajout au passage de `.claude/` au `.gitignore` (artefacts du SDK Claude Code que j'avais commités par erreur lors d'un commit précédent).

## Type de changement

- [x] Contenu, fiche, doc, texte
- [ ] Catalogue
- [ ] Code
- [x] Configuration (`.gitignore`)

## Test plan

- [x] `npm run format:check` passe
- [x] `npm run lint:md` passe
- [x] `npm run lint:spell` passe
- [x] Aucun em-dash dans `CONVENTIONS.md` autre que ceux explicitement légitimes (illustration + nom de projet)
- [x] Le sommaire est à jour
- [x] Toutes les ancres internes fonctionnent

## Issues fermables après merge

- #74 (règle vouvoiement) : documentée.
- #76 (section Code MicroPython sur STeaMi) : documentée.
- #82 (principe fiches éditeur-agnostiques) : documenté.

**Ne pas fermer** (gardent une partie retrofit à faire dans une autre PR) :

- #81 : la convention *« Logiciel STeaMi testé »* est documentée, mais le retrofit sur i03 et i17 reste à faire (PR 2 de la dette technique).
- #84 : la convention *« pas de caractères Unicode difficiles à taper »* est documentée, mais le retrofit sur les fiches déjà publiées et le renommage du nom de projet restent à faire.