### PR TITLE
docs(inovmicro-exao): retrofit des fiches publiées (conventions PR #86)

### DIFF
--- a/.cspell/wikilab.txt
+++ b/.cspell/wikilab.txt
@@ -172,6 +172,8 @@ lumiere
 piézo
 piezo
 morse
+Qwiic
+Sparkfun
 
 # Magnetics — projet Edu-up (BLE Mesh micro:bit / STM32 / MicroPython)
 magnetics

--- a/site/docs/inovmicro-exao/_template/_template.md
+++ b/site/docs/inovmicro-exao/_template/_template.md
@@ -12,7 +12,7 @@ sidebar_position: 2
 <!--
   Icône SVG inline du titre (à côté du H1).
   Le SVG ci-dessous représente la carte STeaMi (placeholder par défaut).
-  Pour ta fiche, remplace-le par une icône thématique de l'activité, en flat-design,
+  Pour votre fiche, remplacez-le par une icône thématique de l'activité, en flat-design,
   dans la couleur du projet (#8a6e18) avec les opacités 0.1 / 0.25 / 1.0
   (cf. CONVENTIONS.md, section "Header").
 -->
@@ -27,16 +27,16 @@ sidebar_position: 2
   <span className="badge badge--warning">MicroPython</span>
 </div>
 
-| Projet        | Durée                | Difficulté                                 | Âge                    | Version MicroPython testée |
-| ------------- | -------------------- | ------------------------------------------ | ---------------------- | -------------------------- |
-| I-Novmicro #2 | <!-- ex: 45 min -->  | <!-- Débutant / Intermédiaire / Avancé --> | <!-- ex: 11-99 ans --> | <!-- ex: 1.23.1 -->        |
+| Projet        | Durée               | Difficulté                                 | Âge                    | Logiciel STeaMi testé |
+| ------------- | ------------------- | ------------------------------------------ | ---------------------- | --------------------- |
+| I-Novmicro #2 | <!-- ex: 45 min --> | <!-- Débutant / Intermédiaire / Avancé --> | <!-- ex: 11-99 ans --> | <!-- ex: 0.23.1 -->   |
 
 ## Matériel et Montage
 
 <!-- Lister le matériel nécessaire, une ligne par item -->
 
 - 1 carte STeaMi
-- 1 câble USB-C
+- 1 câble USB de données (micro-USB pour la STeaMi V1, USB-C pour la STeaMi V2). Attention : un câble qui ne sert qu'à charger un téléphone ne fonctionnera pas.
 - 1 ordinateur avec navigateur web
 
 </div>
@@ -48,7 +48,7 @@ sidebar_position: 2
 
   La taille 225×225 est la convention du wiki ; le comportement responsive global
   du header (icône qui peut s'écraser sur très petit écran) est un sujet
-  qui dépasse le scope d'une fiche unique — à traiter au niveau du CSS global.
+  qui dépasse le scope d'une fiche unique, à traiter au niveau du CSS global.
 -->
 <img src="/img/ressources/inovmicro-exao/<id-fiche>/icone.png" alt="<description courte de la fiche>" style={{width: '225px', height: '225px', objectFit: 'contain', flexShrink: 0}} />
 
@@ -80,7 +80,7 @@ sidebar_position: 2
 
 ---
 
-## Étape 1 — Construire
+## Étape 1 : Construire
 
 <!--
   Décrire le câblage / l'assemblage matériel.
@@ -102,7 +102,7 @@ sidebar_position: 2
 
 ---
 
-## Étape 2 — Programmer
+## Étape 2 : Programmer
 
 <!--
   Présenter le code progressivement :
@@ -112,13 +112,13 @@ sidebar_position: 2
 -->
 
 ```python
-# Testée avec firmware STeaMi 1.23.1
+# Testée avec firmware STeaMi 0.23.1
 #
 ```
 
 ---
 
-## Étape 3 — Améliorer
+## Étape 3 : Améliorer
 
 <!--
   Proposer 2 ou 3 pistes d'extension / variations :
@@ -131,8 +131,8 @@ sidebar_position: 2
 
 <!-- Footer pour fiches originales (i01-i07) : -->
 
-_Cette fiche fait partie du projet [I-Novmicro #2 — Action EXAO](/projets/inovmicro-exao). Contenu sous licence [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/deed.fr)._
+_Cette fiche fait partie du projet [I-Novmicro #2 : Action EXAO](/projets/inovmicro-exao). Contenu sous licence [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/deed.fr)._
 
 <!-- Footer pour fiches portées de Let's STEAM (i08-i22), à utiliser à la place du footer ci-dessus :
-*Cette fiche fait partie du projet [I-Novmicro #2 — Action EXAO](/projets/inovmicro-exao). Adaptée du projet [Let's STEAM](/projets/lets-steam) (fiche [`r1asXX-nom`](/ressources/lets-steam/r1asXX-nom)) sous licence [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/deed.fr).*
+*Cette fiche fait partie du projet [I-Novmicro #2 : Action EXAO](/projets/inovmicro-exao). Adaptée du projet [Let's STEAM](/projets/lets-steam) (fiche [`r1asXX-nom`](/ressources/lets-steam/r1asXX-nom)) sous licence [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/deed.fr).*
 -->

--- a/site/docs/inovmicro-exao/decouverte-steami.md
+++ b/site/docs/inovmicro-exao/decouverte-steami.md
@@ -117,12 +117,12 @@ La STeaMi dispose de deux types de connecteurs pour étendre ses fonctionnalité
 ### Étape 1 : Allumer la carte
 
 - Connectez la carte STeaMi à votre ordinateur avec son câble USB (micro-USB sur la STeaMi V1, USB-C sur la STeaMi V2)
-- La carte s'allume et apparaît comme une clé USB nommée **STEAMI** sur ton ordinateur
+- La carte s'allume et apparaît comme une clé USB nommée **STEAMI** sur l'ordinateur
 - L'écran OLED affiche un message de démarrage
 
 :::info[Conseil]
 
-Si la carte est équipée d'une batterie, tu peux aussi l'allumer sans ordinateur en utilisant l'interrupteur latéral.
+Si la carte est équipée d'une batterie, il est aussi possible de l'allumer sans ordinateur en utilisant l'interrupteur latéral.
 
 :::
 
@@ -138,7 +138,7 @@ Pour commencer, nous recommandons **MicroPython** ou **MakeCode** selon le nivea
 
 ### Étape 3 : Écrire un premier programme
 
-**En MicroPython** : affiche "Hello !" sur l'écran :
+**En MicroPython**, afficher "Hello !" sur l'écran :
 
 ```python
 from steami import display
@@ -146,13 +146,13 @@ from steami import display
 display.show("Hello !")
 ```
 
-**En MakeCode** : utilise le bloc `afficher du texte` avec "Hello !" comme paramètre.
+**En MakeCode**, utiliser le bloc `afficher du texte` avec "Hello !" comme paramètre.
 
 ### Étape 4 : Téléverser le programme
 
-- **Drag and drop** : glisse simplement le fichier `.hex` (MakeCode) ou `.py` (MicroPython) sur le lecteur USB **STEAMI**
+- **Drag and drop** : glisser simplement le fichier `.hex` (MakeCode) ou `.py` (MicroPython) sur le lecteur USB **STEAMI**
 - La LED orange clignote pendant le transfert
-- La carte redémarre automatiquement et exécute ton programme
+- La carte redémarre automatiquement et exécute le programme
 
 :::info[Conseil pour l'enseignant]
 

--- a/site/docs/inovmicro-exao/decouverte-steami.md
+++ b/site/docs/inovmicro-exao/decouverte-steami.md
@@ -20,14 +20,14 @@ sidebar_position: 1
   <span className="badge badge--secondary">MakeCode</span>
 </div>
 
-| Projet | Durée | Difficulté | Âge |
-|---|---|---|---|
-| I-Novmicro #2 | 1h30 | Débutant | 11-99 ans |
+| Projet        | Durée | Difficulté | Âge       | Logiciel STeaMi testé |
+| ------------- | ----- | ---------- | --------- | --------------------- |
+| I-Novmicro #2 | 1h30  | Débutant   | 11-99 ans | 0.23.1                |
 
 ## Matériel
 
 - 1 carte STeaMi
-- 1 câble USB-C
+- 1 câble USB de données (micro-USB pour la STeaMi V1, USB-C pour la STeaMi V2). Attention : un câble qui ne sert qu'à charger un téléphone ne fonctionnera pas.
 - 1 ordinateur avec navigateur web
 - Accès internet pour la documentation en ligne
 
@@ -116,7 +116,7 @@ La STeaMi dispose de deux types de connecteurs pour étendre ses fonctionnalité
 
 ### Étape 1 : Allumer la carte
 
-- Connecte la carte STeaMi à ton ordinateur avec un câble USB-C
+- Connectez la carte STeaMi à votre ordinateur avec son câble USB (micro-USB sur la STeaMi V1, USB-C sur la STeaMi V2)
 - La carte s'allume et apparaît comme une clé USB nommée **STEAMI** sur ton ordinateur
 - L'écran OLED affiche un message de démarrage
 
@@ -138,7 +138,7 @@ Pour commencer, nous recommandons **MicroPython** ou **MakeCode** selon le nivea
 
 ### Étape 3 : Écrire un premier programme
 
-**En MicroPython** — affiche "Hello !" sur l'écran :
+**En MicroPython** : affiche "Hello !" sur l'écran :
 
 ```python
 from steami import display
@@ -146,7 +146,7 @@ from steami import display
 display.show("Hello !")
 ```
 
-**En MakeCode** — utilise le bloc `afficher du texte` avec "Hello !" comme paramètre.
+**En MakeCode** : utilise le bloc `afficher du texte` avec "Hello !" comme paramètre.
 
 ### Étape 4 : Téléverser le programme
 
@@ -227,4 +227,4 @@ La STeaMi permet de réaliser de nombreux projets pédagogiques :
 
 ---
 
-*Cette fiche fait partie du projet [I-Novmicro #2 — Action EXAO](/projets/inovmicro-exao). Contenu sous licence [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/deed.fr). Informations basées sur la [documentation officielle STeaMi](https://wiki.steami.cc/).*
+*Cette fiche fait partie du projet [I-Novmicro #2 : Action EXAO](/projets/inovmicro-exao). Contenu sous licence [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/deed.fr). Informations basées sur la [documentation officielle STeaMi](https://wiki.steami.cc/).*

--- a/site/docs/inovmicro-exao/i03-decouverte-thonny.md
+++ b/site/docs/inovmicro-exao/i03-decouverte-thonny.md
@@ -1,13 +1,13 @@
 ---
 id: i03-decouverte-thonny
-title: Thonny — Prise en main de MicroPython sur la STeaMi
+title: Thonny : Prise en main de MicroPython sur la STeaMi
 sidebar_label: "Thonny"
 sidebar_position: 3
 ---
 
 <div style={{display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: '2rem', marginBottom: '1.5rem'}}>
 <div style={{flex: 1}}>
-# <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="36" height="36" style={{verticalAlign: 'middle', marginRight: '0.5rem', marginBottom: '4px'}}><rect x="3" y="4" width="18" height="14" rx="2" fill="#8a6e18" opacity="0.1"/><rect x="3" y="4" width="18" height="3" rx="1" fill="#8a6e18" opacity="0.3"/><circle cx="5.5" cy="5.5" r="0.5" fill="#8a6e18"/><circle cx="7" cy="5.5" r="0.5" fill="#8a6e18"/><circle cx="8.5" cy="5.5" r="0.5" fill="#8a6e18"/><polyline points="6,11 8,13 6,15" fill="none" stroke="#8a6e18" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round"/><polyline points="9,11 11,13 9,15" fill="none" stroke="#8a6e18" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round"/><line x1="13" y1="15" x2="18" y2="15" stroke="#8a6e18" strokeWidth="1.2" strokeLinecap="round"/><line x1="6" y1="20" x2="18" y2="20" stroke="#8a6e18" strokeWidth="1.5" strokeLinecap="round"/><line x1="12" y1="18" x2="12" y2="20" stroke="#8a6e18" strokeWidth="1.5"/></svg> Thonny — Prise en main de MicroPython sur la STeaMi
+# <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="36" height="36" style={{verticalAlign: 'middle', marginRight: '0.5rem', marginBottom: '4px'}}><rect x="3" y="4" width="18" height="14" rx="2" fill="#8a6e18" opacity="0.1"/><rect x="3" y="4" width="18" height="3" rx="1" fill="#8a6e18" opacity="0.3"/><circle cx="5.5" cy="5.5" r="0.5" fill="#8a6e18"/><circle cx="7" cy="5.5" r="0.5" fill="#8a6e18"/><circle cx="8.5" cy="5.5" r="0.5" fill="#8a6e18"/><polyline points="6,11 8,13 6,15" fill="none" stroke="#8a6e18" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round"/><polyline points="9,11 11,13 9,15" fill="none" stroke="#8a6e18" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round"/><line x1="13" y1="15" x2="18" y2="15" stroke="#8a6e18" strokeWidth="1.2" strokeLinecap="round"/><line x1="6" y1="20" x2="18" y2="20" stroke="#8a6e18" strokeWidth="1.5" strokeLinecap="round"/><line x1="12" y1="18" x2="12" y2="20" stroke="#8a6e18" strokeWidth="1.5"/></svg> Thonny : Prise en main de MicroPython sur la STeaMi
 <div style={{display: 'flex', gap: '0.5rem', flexWrap: 'wrap', marginBottom: '1rem'}}>
   <span className="badge badge--primary">Informatique</span>
   <span className="badge badge--primary">Technologie</span>
@@ -16,7 +16,7 @@ sidebar_position: 3
   <span className="badge badge--warning">MicroPython</span>
   <span className="badge badge--secondary">Thonny</span>
 </div>
-| Projet        | Durée   | Difficulté | Âge       | Version STeaMi testée |
+| Projet        | Durée   | Difficulté | Âge       | Logiciel STeaMi testé |
 | ------------- | ------- | ---------- | --------- | --------------------- |
 | I-Novmicro #2 | 40 min  | Débutant   | 11-99 ans | 0.23.1                |
 
@@ -35,7 +35,7 @@ sidebar_position: 3
 ## De quoi parle-t-on ?
 
 Programmer une carte microcontrôleur peut sembler intimidant : plusieurs logiciels à installer, environnement à configurer, code à envoyer vers la carte…
-**Thonny** est un éditeur Python conçu pour l'apprentissage qui simplifie cette mise en route. Couplé à **MicroPython** — une version de Python adaptée aux cartes électroniques — une fois installé sur la STeaMi, il offre un environnement **gratuit et hors-ligne** où l'on peut écrire du code, le tester en direct dans le **REPL** (une fenêtre de dialogue où l'on tape une instruction et la carte y répond immédiatement), et déboguer pas-à-pas.
+**Thonny** est un éditeur Python conçu pour l'apprentissage qui simplifie cette mise en route. Couplé à **MicroPython** : une version de Python adaptée aux cartes électroniques, une fois installé sur la STeaMi, il offre un environnement **gratuit et hors-ligne** où l'on peut écrire du code, le tester en direct dans le **REPL** (une fenêtre de dialogue où l'on tape une instruction et la carte y répond immédiatement), et déboguer pas-à-pas.
 
 Cette fiche met en place tout l'environnement de travail : installation de Thonny, installation de MicroPython sur la carte, configuration de la communication entre Thonny et la carte, et écriture d'un premier programme qui pilote la **LED RGB** de la STeaMi avec ses **boutons A et B**. À privilégier en salle informatique avec postes fixes ; pour des postes verrouillés ou en mobilité, préférer **Vittascience** (en ligne).
 
@@ -50,7 +50,7 @@ Cette fiche met en place tout l'environnement de travail : installation de Thonn
 - Identifier la différence entre exécution temporaire (Run) et programme persistant (`main.py`)
 ---
 
-## Étape 1 — Construire
+## Étape 1 : Construire
 
 Ici, "construire" veut dire mettre en place l'environnement logiciel : installer Thonny, installer MicroPython sur la carte, et configurer la communication entre les deux.
 
@@ -165,7 +165,7 @@ Type "help()" for more information.
 
 ---
 
-## Étape 2 — Programmer
+## Étape 2 : Programmer
 
 Premier programme : **changer la couleur de la LED RGB selon le bouton enfoncé**. Sur la STeaMi, la LED RGB s'allume en écrivant `1` sur la broche, et s'éteint avec `0`. Les boutons A et B, eux, fonctionnent à l'envers : leur valeur vaut `1` au repos et passe à `0` quand on appuie (une résistance présente sur la carte impose ce comportement, on n'a rien à faire dans le code).
 
@@ -173,9 +173,9 @@ Premier programme : **changer la couleur de la LED RGB selon le bouton enfoncé*
 
 | Composant       | Nom dans le programme | Comportement                          |
 | --------------- | --------------------- | ------------------------------------- |
-| LED RGB — Rouge | `LED_RED`             | 1 = allumée, 0 = éteinte              |
-| LED RGB — Verte | `LED_GREEN`           | 1 = allumée, 0 = éteinte              |
-| LED RGB — Bleue | `LED_BLUE`            | 1 = allumée, 0 = éteinte              |
+| LED RGB Rouge | `LED_RED`             | 1 = allumée, 0 = éteinte              |
+| LED RGB Verte | `LED_GREEN`           | 1 = allumée, 0 = éteinte              |
+| LED RGB Bleue | `LED_BLUE`            | 1 = allumée, 0 = éteinte              |
 | Bouton A        | `A_BUTTON`            | 0 = appuyé, 1 = relâché               |
 | Bouton B        | `B_BUTTON`            | 0 = appuyé, 1 = relâché               |
 
@@ -184,7 +184,7 @@ Premier programme : **changer la couleur de la LED RGB selon le bouton enfoncé*
 ```python
 # Testée avec firmware STeaMi 0.23.1
 #
-# Premier programme STeaMi avec Thonny — LED RGB + boutons A/B
+# Premier programme STeaMi avec Thonny, LED RGB + boutons A/B
 # - Bouton A     -> LED rouge
 # - Bouton B     -> LED verte
 # - A + B        -> LED bleue
@@ -283,7 +283,7 @@ Quand un programme est déjà en cours d'exécution sur la carte (par exemple un
 
 ---
 
-## Étape 3 — Améliorer
+## Étape 3 : Améliorer
 
 Une fois le premier programme fonctionnel, trois pistes pour aller plus loin avec Thonny.
 
@@ -291,7 +291,7 @@ Une fois le premier programme fonctionnel, trois pistes pour aller plus loin ave
 
 Le **REPL** (`>>>` dans le panneau Shell) permet de tester du code **directement sur la carte**, sans créer de fichier. Pratique pour la découverte et le débogage.
 
-Dans l'exemple ci-dessous, les `>>>` représentent le prompt — c'est ce que Thonny affiche pour signaler qu'il attend une commande. Ne pas les recopier dans l'éditeur, tapez uniquement ce qui suit le prompt.
+Dans l'exemple ci-dessous, les `>>>` représentent le prompt, c'est ce que Thonny affiche pour signaler qu'il attend une commande. Ne pas les recopier dans l'éditeur, tapez uniquement ce qui suit le prompt.
 
 ```python
 # Allumer la LED rouge à la main
@@ -360,14 +360,14 @@ Le debugger Thonny est plus efficace en local sur le PC qu'en cible embarquée. 
 
 ## Ressources et liens utiles
 
-- [Site STeaMi](https://www.steami.cc/) — présentation matérielle
-- [Wiki STeaMi — Thonny](https://wiki.steami.cc/docs/software/micropython/thonny)
-- [Wiki STeaMi — Premiers pas](https://wiki.steami.cc/docs/software/getting-started)
-- [Wiki STeaMi — Hardware](https://wiki.steami.cc/docs/hardware/) (pinout détaillé)
+- [Site STeaMi](https://www.steami.cc/) : présentation matérielle
+- [Wiki STeaMi : Thonny](https://wiki.steami.cc/docs/software/micropython/thonny)
+- [Wiki STeaMi : Premiers pas](https://wiki.steami.cc/docs/software/getting-started)
+- [Wiki STeaMi : Hardware](https://wiki.steami.cc/docs/hardware/) (pinout détaillé)
 - [Drivers MicroPython STeaMi](https://github.com/steamicc/micropython-steami-lib)
 - [Documentation MicroPython](https://docs.micropython.org/)
 - [thonny.org](https://thonny.org/)
-- [MOOC FUN — Programmer un objet avec MicroPython](https://www.fun-mooc.fr/fr/cours/programmer-un-objet-avec-micropython/)
+- [MOOC FUN : Programmer un objet avec MicroPython](https://www.fun-mooc.fr/fr/cours/programmer-un-objet-avec-micropython/)
 ---
 
-_Cette fiche fait partie du projet [I-Novmicro #2 — Action EXAO](/projets/inovmicro-exao). Contenu sous licence [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/deed.fr). Informations basées sur la [documentation officielle STeaMi](https://wiki.steami.cc/)._
+_Cette fiche fait partie du projet [I-Novmicro #2 : Action EXAO](/projets/inovmicro-exao). Contenu sous licence [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/deed.fr). Informations basées sur la [documentation officielle STeaMi](https://wiki.steami.cc/)._

--- a/site/docs/inovmicro-exao/i03-decouverte-thonny.md
+++ b/site/docs/inovmicro-exao/i03-decouverte-thonny.md
@@ -1,6 +1,6 @@
 ---
 id: i03-decouverte-thonny
-title: Thonny : Prise en main de MicroPython sur la STeaMi
+title: "Thonny : Prise en main de MicroPython sur la STeaMi"
 sidebar_label: "Thonny"
 sidebar_position: 3
 ---

--- a/site/docs/inovmicro-exao/i11-capteur-lumiere.md
+++ b/site/docs/inovmicro-exao/i11-capteur-lumiere.md
@@ -26,7 +26,7 @@ sidebar_position: 11
 - 1 carte STeaMi
 - 1 câble USB de données (micro-USB pour la STeaMi V1, USB-C pour la STeaMi V2). Attention : un câble qui ne sert qu'à charger un téléphone ne fonctionnera pas.
 - 1 ordinateur sous Windows, macOS ou Linux
-- Un IDE MicroPython installé et configuré pour la STeaMi. Voir la fiche [Thonny — Prise en main de MicroPython](/ressources/inovmicro-exao/i03-decouverte-thonny) pour la mise en place — tout autre éditeur compatible MicroPython (Mu, VS Code, Vittascience, `mpremote`…) fonctionne aussi.
+- Un IDE MicroPython installé et configuré pour la STeaMi. Voir la fiche [Thonny : Prise en main de MicroPython](/ressources/inovmicro-exao/i03-decouverte-thonny) pour la mise en place, tout autre éditeur compatible MicroPython (Mu, VS Code, Vittascience, `mpremote`…) fonctionne aussi.
 </div>
 <img src="/img/ressources/inovmicro-exao/i11-capteur-lumiere/icone.png" alt="Capteur de lumière sur la STeaMi" style={{width: '225px', height: '225px', objectFit: 'contain', flexShrink: 0}} />
 </div>
@@ -37,7 +37,7 @@ sidebar_position: 11
 
 Cette fiche explore une caractéristique clé de l'informatique embarquée : la possibilité de **mesurer une grandeur physique** avec un capteur, et de représenter graphiquement la façon dont cette grandeur **varie dans le temps**.
 
-La STeaMi intègre un capteur **APDS-9960** capable de mesurer la lumière ambiante, mais aussi les composantes **rouge, verte et bleue** de cette lumière, ainsi que la proximité d'un objet et certains gestes. Pour cette fiche, on se concentre sur la mesure de la lumière ambiante — la couleur sera abordée dans l'étape « Améliorer ».
+La STeaMi intègre un capteur **APDS-9960** capable de mesurer la lumière ambiante, mais aussi les composantes **rouge, verte et bleue** de cette lumière, ainsi que la proximité d'un objet et certains gestes. Pour cette fiche, on se concentre sur la mesure de la lumière ambiante, la couleur sera abordée dans l'étape « Améliorer ».
 
 L'avantage du capteur intégré : pas de breadboard ni de câblage. Tout passe par le bus **I2C** interne de la carte, ce qui permet de se concentrer sur la programmation et l'analyse des mesures.
 
@@ -53,7 +53,7 @@ L'avantage du capteur intégré : pas de breadboard ni de câblage. Tout passe p
 
 ---
 
-## Étape 1 — Construire
+## Étape 1 : Construire
 
 Ici, "construire" est rapide : tout le matériel nécessaire est déjà sur la carte.
 
@@ -74,17 +74,17 @@ Le capteur **APDS-9960** est soudé sur la face avant de la STeaMi, près de l'�
 
 :::info[Qu'est-ce qu'un capteur numérique I2C ?]
 
-Contrairement à une photorésistance qui fournit une tension variable lue par un convertisseur analogique-numérique, l'APDS-9960 est un **capteur numérique** : il fait lui-même la mesure et la conversion, puis envoie le résultat sous forme de **nombre** à la carte via une liaison appelée **I2C** (deux fils : SDA pour les données, SCL pour l'horloge). C'est ce qui permet d'avoir un seul composant qui mesure à la fois la lumière, la couleur, la proximité et les gestes — sans câblage supplémentaire.
+Contrairement à une photorésistance qui fournit une tension variable lue par un convertisseur analogique-numérique, l'APDS-9960 est un **capteur numérique** : il fait lui-même la mesure et la conversion, puis envoie le résultat sous forme de **nombre** à la carte via une liaison appelée **I2C** (deux fils : SDA pour les données, SCL pour l'horloge). C'est ce qui permet d'avoir un seul composant qui mesure à la fois la lumière, la couleur, la proximité et les gestes, sans câblage supplémentaire.
 
 :::
 
 ### Connecter la carte à l'ordinateur
 
-Brancher la STeaMi à l'ordinateur via le câble USB. Si votre IDE MicroPython est déjà configuré (voir la fiche [Thonny — Prise en main de MicroPython](/ressources/inovmicro-exao/i03-decouverte-thonny) si vous démarrez), la console MicroPython doit afficher le prompt `>>>`.
+Brancher la STeaMi à l'ordinateur via le câble USB. Si votre IDE MicroPython est déjà configuré (voir la fiche [Thonny : Prise en main de MicroPython](/ressources/inovmicro-exao/i03-decouverte-thonny) si vous démarrez), la console MicroPython doit afficher le prompt `>>>`.
 
 ### Vérifier que le capteur répond
 
-Avant d'écrire le programme principal, on peut vérifier dans le **REPL** que le capteur est bien détecté sur le bus I2C. Les `>>>` ci-dessous sont le prompt affiché par MicroPython dans la console pour indiquer qu'il attend une commande — ne les tapez pas, écrivez seulement ce qui suit.
+Avant d'écrire le programme principal, on peut vérifier dans le **REPL** que le capteur est bien détecté sur le bus I2C. Les `>>>` ci-dessous sont le prompt affiché par MicroPython dans la console pour indiquer qu'il attend une commande, ne les tapez pas, écrivez seulement ce qui suit.
 
 ```python
 >>> from machine import I2C
@@ -93,11 +93,11 @@ Avant d'écrire le programme principal, on peut vérifier dans le **REPL** que l
 ['0x1e', '0x29', '0x39', '0x55', '0x5d', '0x5f', '0x6b']
 ```
 
-L'adresse `0x39` correspond à l'APDS-9960. Si elle apparaît, le capteur répond — on peut passer à la programmation.
+L'adresse `0x39` correspond à l'APDS-9960. Si elle apparaît, le capteur répond, on peut passer à la programmation.
 
 ---
 
-## Étape 2 — Programmer
+## Étape 2 : Programmer
 
 Premier programme : **lire la lumière ambiante toutes les demi-secondes et l'afficher dans la console**, en utilisant la LED RGB comme indicateur visuel (verte si lumière forte, rouge si sombre).
 
@@ -106,7 +106,7 @@ Premier programme : **lire la lumière ambiante toutes les demi-secondes et l'af
 ```python
 # Testée avec firmware STeaMi 0.23.1
 #
-# Capteur de lumière — lecture périodique de la lumière ambiante
+# Capteur de lumière, lecture périodique de la lumière ambiante
 # avec retour visuel sur la LED RGB :
 #   - lumière forte  -> LED verte
 #   - lumière faible -> LED rouge
@@ -163,7 +163,7 @@ Le programme tient en quatre éléments :
 
 :::info[Plage de valeurs]
 
-Le capteur retourne une valeur sur **16 bits**, donc entre **0** (obscurité totale) et **65535** (lumière très forte). En conditions normales d'éclairage de salle, on observe typiquement des valeurs de quelques dizaines à quelques milliers — il faudra peut-être ajuster `SEUIL_CLAIR` selon l'environnement. Une lampe pointée directement sur le capteur peut faire saturer la valeur à 65535.
+Le capteur retourne une valeur sur **16 bits**, donc entre **0** (obscurité totale) et **65535** (lumière très forte). En conditions normales d'éclairage de salle, on observe typiquement des valeurs de quelques dizaines à quelques milliers, il faudra peut-être ajuster `SEUIL_CLAIR` selon l'environnement. Une lampe pointée directement sur le capteur peut faire saturer la valeur à 65535.
 
 :::
 
@@ -199,7 +199,7 @@ Si vous utilisez Thonny, l'éditeur propose un **traceur de variables** : **Affi
 
 ---
 
-## Étape 3 — Améliorer
+## Étape 3 : Améliorer
 
 Trois pistes pour aller plus loin avec le capteur de lumière.
 
@@ -214,9 +214,9 @@ Une amélioration plus avancée consiste à **transformer la valeur brute en pou
 
 ### 2. Lire les composantes RGB de la lumière
 
-L'APDS-9960 ne se contente pas de mesurer la quantité de lumière : il mesure aussi ses **composantes rouge, verte et bleue**. C'est très différent — on peut, par exemple, distinguer la lumière d'une LED rouge de celle d'une LED verte, alors que la simple lecture de `ambient_light()` donnerait à peu près la même valeur dans les deux cas.
+L'APDS-9960 ne se contente pas de mesurer la quantité de lumière : il mesure aussi ses **composantes rouge, verte et bleue**. C'est très différent, on peut, par exemple, distinguer la lumière d'une LED rouge de celle d'une LED verte, alors que la simple lecture de `ambient_light()` donnerait à peu près la même valeur dans les deux cas.
 
-Les lignes ci-dessous remplacent l'appel à `ambient_light()` dans la boucle du programme précédent — `sensor` est déjà initialisé en haut de fichier.
+Les lignes ci-dessous remplacent l'appel à `ambient_light()` dans la boucle du programme précédent, `sensor` est déjà initialisé en haut de fichier.
 
 ```python
 # Lire les quatre canaux du capteur (clair + RGB)
@@ -247,10 +247,10 @@ else:
 
 ## Aller plus loin
 
-- [Documentation du driver APDS-9960 sur la STeaMi](https://github.com/steamicc/micropython-steami-lib/blob/main/lib/apds9960/README.md) — toutes les fonctions disponibles, y compris la proximité et les gestes.
-- [Fiche technique du capteur APDS-9960 (Broadcom)](https://www.broadcom.com/products/optical-sensors/integrated-ambient-light-and-proximity-sensors/apds-9960) — caractéristiques détaillées du composant.
-- [Wiki STeaMi — Capteurs internes](https://wiki.steami.cc/docs/hardware/) — liste de tous les capteurs présents sur la carte.
-- [Documentation MicroPython — module `machine.I2C`](https://docs.micropython.org/en/latest/library/machine.I2C.html) — pour comprendre comment fonctionne le bus I2C en MicroPython.
+- [Documentation du driver APDS-9960 sur la STeaMi](https://github.com/steamicc/micropython-steami-lib/blob/main/lib/apds9960/README.md) : toutes les fonctions disponibles, y compris la proximité et les gestes.
+- [Fiche technique du capteur APDS-9960 (Broadcom)](https://www.broadcom.com/products/optical-sensors/integrated-ambient-light-and-proximity-sensors/apds-9960) : caractéristiques détaillées du composant.
+- [Wiki STeaMi : Capteurs internes](https://wiki.steami.cc/docs/hardware/) : liste de tous les capteurs présents sur la carte.
+- [Documentation MicroPython : module `machine.I2C`](https://docs.micropython.org/en/latest/library/machine.I2C.html) : pour comprendre comment fonctionne le bus I2C en MicroPython.
 ---
 
-_Cette fiche fait partie du projet [I-Novmicro #2 — Action EXAO](/projets/inovmicro-exao). Adaptée du projet [Let's STEAM](/projets/lets-steam) (fiche [`r1as04-capteur-lumiere`](/ressources/lets-steam/r1as04-capteur-lumiere)) sous licence [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/deed.fr)._
+_Cette fiche fait partie du projet [I-Novmicro #2 : Action EXAO](/projets/inovmicro-exao). Adaptée du projet [Let's STEAM](/projets/lets-steam) (fiche [`r1as04-capteur-lumiere`](/ressources/lets-steam/r1as04-capteur-lumiere)) sous licence [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/deed.fr)._

--- a/site/docs/inovmicro-exao/i13-code-morse.md
+++ b/site/docs/inovmicro-exao/i13-code-morse.md
@@ -1,5 +1,5 @@
 ---
-id: i13-morse
+id: i13-code-morse
 title: Envoyer des messages en code Morse avec la STeaMi
 sidebar_label: "Code Morse"
 sidebar_position: 13
@@ -318,5 +318,5 @@ C'est un excellent exercice pour découvrir les **structures de données** (dict
 - [Wiki STeaMi : Boutons et buzzer](https://wiki.steami.cc/docs/hardware/main-components/buttons-audio) : description matérielle du buzzer et des boutons sur la carte.
 ---
 
-_Cette fiche fait partie du projet [I-Novmicro #2 — Action EXAO](/projets/inovmicro-exao). Adaptée du projet [Let's STEAM](/projets/lets-steam) (fiche [`r1as06-morse`](/ressources/lets-steam/r1as06-morse)) sous licence [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/deed.fr)._
+_Cette fiche fait partie du projet [I-Novmicro #2 : Action EXAO](/projets/inovmicro-exao). Adaptée du projet [Let's STEAM](/projets/lets-steam) (fiche [`r1as06-morse`](/ressources/lets-steam/r1as06-morse)) sous licence [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/deed.fr)._
 

--- a/site/docs/inovmicro-exao/i17-texte-oled.md
+++ b/site/docs/inovmicro-exao/i17-texte-oled.md
@@ -16,7 +16,7 @@ sidebar_position: 17
   <span className="badge badge--warning">MicroPython</span>
 </div>
 
-| Projet        | Durée  | Difficulté | Âge       | Version MicroPython testée |
+| Projet        | Durée  | Difficulté | Âge       | Logiciel STeaMi testé |
 | ------------- | ------ | ---------- | --------- | -------------------------- |
 | I-Novmicro #2 | 60 min | Intermédiaire   | 11-15 ans | 0.23.1                     |
 
@@ -34,7 +34,7 @@ sidebar_position: 17
 
 ## De quoi parle-t-on ?
 
-Programmer une carte électronique, c'est parfois travailler dans une « boîte noire » : on ne voit pas ce qui s'y passe. L'écran OLED de la STeaMi permet d'**afficher des informations issues du programme** — un message d'accueil, l'état d'un capteur, la valeur d'une variable — pour rendre visible le comportement de la carte.
+Programmer une carte électronique, c'est parfois travailler dans une « boîte noire » : on ne voit pas ce qui s'y passe. L'écran OLED de la STeaMi permet d'**afficher des informations issues du programme** : un message d'accueil, l'état d'un capteur, la valeur d'une variable, pour rendre visible le comportement de la carte.
 
 Cette fiche met en pratique l'affichage de texte sur l'écran OLED 128×128 de la STeaMi, en MicroPython, à l'aide de la bibliothèque haut niveau `steami_screen`.
 
@@ -49,7 +49,7 @@ Cette fiche met en pratique l'affichage de texte sur l'écran OLED 128×128 de l
 - Faire évoluer l'affichage dans le temps pour suivre l'état d'une variable du programme
 ---
 
-## Étape 1 — Construire
+## Étape 1 : Construire
 
 Sur la STeaMi, l'écran est déjà câblé en interne. Il ne reste que deux choses à faire avant de programmer.
 
@@ -91,7 +91,7 @@ Sur la STeaMi, l'écran est déjà câblé en interne. Il ne reste que deux chos
 
 ---
 
-## Étape 2 — Programmer
+## Étape 2 : Programmer
 
 ### Code
 
@@ -153,7 +153,7 @@ La fonction **`screen.text(texte, at=..., color=..., scale=...)`** permet d'affi
     <text x="28" y="183" textAnchor="middle" fontFamily="monospace" fontSize="9" fill="#8a6e18">"SW"</text>
     <text x="172" y="183" textAnchor="middle" fontFamily="monospace" fontSize="9" fill="#8a6e18">"SE"</text>
     <text x="100" y="104" textAnchor="middle" fontFamily="monospace" fontSize="11" fontWeight="bold" fill="#8a6e18">"CENTER"</text>
-    <text x="100" y="200" textAnchor="middle" fontFamily="sans-serif" fontSize="8" fill="#8a6e18" opacity="0.7">Écran 128 × 128 pixels — origine (0,0) en haut à gauche</text>
+    <text x="100" y="200" textAnchor="middle" fontFamily="sans-serif" fontSize="8" fill="#8a6e18" opacity="0.7">Écran 128 × 128 pixels, origine (0,0) en haut à gauche</text>
   </svg>
   <figcaption style={{fontStyle: 'italic', marginTop: '0.5rem'}}>
     Les neuf positions cardinales utilisables avec `screen.text(texte, at=...)`.
@@ -175,7 +175,7 @@ Couleurs disponibles dans `steami_screen` : `BLACK`, `DARK`, `GRAY`, `LIGHT`, `W
 :::warning Étape importante : `screen.show()`
 On peut imaginer l'écran de la STeaMi comme un tableau noir caché derrière un voile. Les fonctions `text()`, `clear()`, `pixel()`… dessinent sur le tableau, mais le voile reste en place tant qu'on n'a pas appelé `screen.show()`. À ce moment-là, le voile tombe et tout ce qu'on a dessiné apparaît d'un coup.
 
-Techniquement, ce « tableau caché » s'appelle un **framebuffer** — une zone de mémoire dans laquelle on prépare l'image, avant de la transférer vers l'écran.
+Techniquement, ce « tableau caché » s'appelle un **framebuffer** : une zone de mémoire dans laquelle on prépare l'image, avant de la transférer vers l'écran.
 :::
 
 :::tip API bas niveau
@@ -184,9 +184,9 @@ Si vous avez besoin de coordonnées exactes (par exemple pour une animation pixe
 
 ---
 
-## Étape 3 — Améliorer
+## Étape 3 : Améliorer
 
-Quatre défis dans l'esprit de la fiche d'origine, à faire dans l'ordre. Chaque défi part du même bloc d'initialisation que l'étape 2 — on le rappelle ici une fois pour gagner de la place :
+Quatre défis dans l'esprit de la fiche d'origine, à faire dans l'ordre. Chaque défi part du même bloc d'initialisation que l'étape 2, on le rappelle ici une fois pour gagner de la place :
 
 ```python
 # Bloc d'initialisation commun à tous les défis ci-dessous.
@@ -205,7 +205,7 @@ display = SSD1327Display(raw)
 screen  = Screen(display)
 ```
 
-### Défi 1 — Afficher le cœur en grand
+### Défi 1 : Afficher le cœur en grand
 
 `screen.text()` accepte un paramètre `scale` qui agrandit le texte. Essayer `screen.text("<3", at="CENTER", scale=3)`. Quelle est la limite avant que le texte ne sorte de l'écran ?
 
@@ -220,7 +220,7 @@ screen  = Screen(display)
   </figcaption>
 </figure>
 
-### Défi 2 — Animation à La Linea
+### Défi 2 : Animation à La Linea
 
 Avec une boucle `while`, créer une animation simple qui fait avancer un personnage minimaliste fait des symboles `|` et `_`. Utiliser `sleep_ms(100)` pour ralentir le mouvement et ne pas oublier d'appeler `screen.clear()` au début de chaque image pour effacer l'écran.
 
@@ -250,13 +250,13 @@ while True:
   </figcaption>
 </figure>
 
-### Défi 3 — État du bouton USER
+### Défi 3 : État du bouton USER
 
 Afficher en temps réel si le bouton A de la STeaMi est pressé ou non, par exemple avec `screen.title("A: ON")` ou `screen.title("A: OFF")`. Que se passe-t-il avec un `sleep_ms(1000)` long dans la boucle ? Comment améliorer la réactivité ? *(Indice : raccourcir le délai. Pour aller plus loin (terminale informatique), explorer la programmation asynchrone avec `uasyncio`.)*
 
-### Défi 4 — Tableau de bord capteurs
+### Défi 4 : Tableau de bord capteurs
 
-Afficher simultanément plusieurs valeurs en utilisant les positions cardinales pour répartir l'information sur l'écran. Voici un squelette qui anime des valeurs simulées — l'objectif ici est de maîtriser la **mise en page**, pas la lecture des capteurs.
+Afficher simultanément plusieurs valeurs en utilisant les positions cardinales pour répartir l'information sur l'écran. Voici un squelette qui anime des valeurs simulées, l'objectif ici est de maîtriser la **mise en page**, pas la lecture des capteurs.
 
 ```python
 # Testée avec firmware STeaMi 0.23.1
@@ -267,7 +267,7 @@ from math import sin
 
 t = 0
 while True:
-    # Valeurs simulées — à remplacer par la lecture réelle des capteurs.
+    # Valeurs simulées, à remplacer par la lecture réelle des capteurs.
     temp = 22 + 3 * sin(t / 5)
     humi = 50 + 10 * sin(t / 7)
     accel_z = sin(t / 3)
@@ -300,12 +300,12 @@ Une fois la mise en page maîtrisée, brancher de vraies valeurs en lisant les c
 
 ## Ressources et liens utiles
 
-- [Wiki STeaMi — Hardware](https://wiki.steami.cc/docs/hardware/) (pinout détaillé, écran OLED)
-- [Drivers MicroPython STeaMi](https://github.com/steamicc/micropython-steami-lib) — code source de `steami_screen` et `ssd1327`
-- [Documentation `framebuf`](https://docs.micropython.org/en/latest/library/framebuf.html) — API bas niveau de dessin sur framebuffer
+- [Wiki STeaMi : Hardware](https://wiki.steami.cc/docs/hardware/) (pinout détaillé, écran OLED)
+- [Drivers MicroPython STeaMi](https://github.com/steamicc/micropython-steami-lib) : code source de `steami_screen` et `ssd1327`
+- [Documentation `framebuf`](https://docs.micropython.org/en/latest/library/framebuf.html) : API bas niveau de dessin sur framebuffer
 - [Documentation MicroPython](https://docs.micropython.org/)
-- **Widgets de `steami_screen`** : `title()`, `subtitle()`, `value()`, `bar()`, `gauge()`, `graph()`, `menu()`, `compass()`, `watch()`, `face()` — pour transformer rapidement la STeaMi en tableau de bord ou en jouet interactif.
+- **Widgets de `steami_screen`** : `title()`, `subtitle()`, `value()`, `bar()`, `gauge()`, `graph()`, `menu()`, `compass()`, `watch()`, `face()`, pour transformer rapidement la STeaMi en tableau de bord ou en jouet interactif.
 ---
 
-_Cette fiche fait partie du projet [I-Novmicro #2 — Action EXAO](/projets/inovmicro-exao). Adaptée du projet [Let's STEAM](/projets/lets-steam) (fiche [`r1as10-ecran-oled`](/ressources/lets-steam/r1as10-ecran-oled)) sous licence [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/deed.fr). Informations basées sur la [documentation officielle STeaMi](https://wiki.steami.cc/)._
+_Cette fiche fait partie du projet [I-Novmicro #2 : Action EXAO](/projets/inovmicro-exao). Adaptée du projet [Let's STEAM](/projets/lets-steam) (fiche [`r1as10-ecran-oled`](/ressources/lets-steam/r1as10-ecran-oled)) sous licence [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/deed.fr). Informations basées sur la [documentation officielle STeaMi](https://wiki.steami.cc/)._
 

--- a/site/src/data/projects.ts
+++ b/site/src/data/projects.ts
@@ -447,7 +447,7 @@ export const projectsInfo: Record<Project, ProjectInfo> = {
   },
   'inovmicro-exao': {
     id: 'inovmicro-exao',
-    name: 'I-Novmicro #2 — Action EXAO',
+    name: 'I-Novmicro #2 : Action EXAO',
     logo: '/img/logos/exao.png',
     color: '#8a6e18',
     colorSecondary: '#8a6e18',

--- a/site/src/data/resources.ts
+++ b/site/src/data/resources.ts
@@ -3675,7 +3675,7 @@ export const resources: Resource[] = [
     slug: '/ressources/inovmicro-exao/i17-texte-oled',
     project: 'inovmicro-exao',
     summary:
-      "Porter sur la STeaMi la fiche Let's STEAM R1AS10 : afficher du texte sur l'écran OLED 128×128 intégré, en MicroPython avec la bibliothèque steami_screen. Positions cardinales, framebuffer, animation et mise en page d'un tableau de bord.",
+      "Afficher du texte sur l'écran OLED 128×128 intégré à la STeaMi, en MicroPython avec la bibliothèque steami_screen. Positions cardinales, framebuffer, animation et mise en page d'un tableau de bord.",
     disciplines: ['informatique', 'technologie'],
     tools: ['steami'],
     software: ['python'],
@@ -3736,9 +3736,9 @@ export const resources: Resource[] = [
     thumbnail: '/img/ressources/inovmicro-exao/i11-capteur-lumiere/icone.png',
   },
   {
-    id: 'i13-morse',
-    title: 'Découvrir le buzzer de la STeaMi',
-    slug: '/ressources/inovmicro-exao/i13-morse',
+    id: 'i13-code-morse',
+    title: 'Envoyer des messages en code Morse avec la STeaMi',
+    slug: '/ressources/inovmicro-exao/i13-code-morse',
     project: 'inovmicro-exao',
     summary:
       "Programmer un émetteur Morse avec le buzzer piézo intégré et les boutons A et B de la STeaMi. Génération d'une fréquence audio par bascule rapide d'une broche, codage à longueur variable et envoi de messages en code Morse international.",


### PR DESCRIPTION
## Résumé

Application en bloc des conventions consolidées dans la PR #86 (`CONVENTIONS.md`) sur les **5 fiches I-Novmicro #2 déjà publiées + le template**.

**Issues adressées** : #68, #75, #77, #81 (retrofit), #83, #84 (retrofit).

## Détail des changements

### 1. Nom du projet (#84)

`I-Novmicro #2 — Action EXAO` (em-dash) devient `I-Novmicro #2 : Action EXAO` :

- dans [`site/src/data/projects.ts`](../blob/main/site/src/data/projects.ts) (canonique)
- dans les 6 footers de fiches qui reproduisent ce nom

### 2. Em-dashes retirés (#84)

**63 occurrences** retirées des 5 fiches publiées + template. Remplacements selon contexte :

| Pattern | Avant | Après |
|---|---|---|
| Titres d'étape | `## Étape X — XXX` | `## Étape X : XXX` |
| Liens *« Aller plus loin »* | `[texte](url) — desc` | `[texte](url) : desc` |
| Défis | `### Défi N — XXX` | `### Défi N : XXX` |
| Sous-titres wiki STeaMi | `Wiki STeaMi — Thonny` | `Wiki STeaMi : Thonny` |
| Tableau brochage | `LED RGB — Rouge` | `LED RGB Rouge` |
| Incises en prose | `... texte — texte ...` | `... texte, texte ...` |

**Zéro em-dash restant** dans les `.md` du projet I-Novmicro.

Hors scope : les em-dashes dans `projects.ts` sur les labels Erasmus+ (`KA201 — Partenariat stratégique`, etc.) sont des noms officiels de programmes, laissés tels quels.

### 3. Label "Logiciel STeaMi testé" rétroporté (#81 retrofit)

Appliqué sur les fiches qui utilisaient encore les anciens labels :

- [`i03-decouverte-thonny.md`](../blob/main/site/docs/inovmicro-exao/i03-decouverte-thonny.md) : *« Version STeaMi testée »* → *« Logiciel STeaMi testé »*
- [`i17-texte-oled.md`](../blob/main/site/docs/inovmicro-exao/i17-texte-oled.md) : *« Version MicroPython testée »* → *« Logiciel STeaMi testé »*

### 4. decouverte-steami mise à jour (#68)

- Tableau header passé de 4 à 5 colonnes (ajout *« Logiciel STeaMi testé »* = 0.23.1).
- Câble USB-C précisé en V1/V2 (micro-USB V1, USB-C V2) avec note sur les câbles de charge.
- Tutoiement résiduel *« Connecte la carte STeaMi à ton ordinateur »* passé au vouvoiement.

### 5. Summary i17 reformulé (#77)

`"Porter sur la STeaMi la fiche Let's STEAM R1AS10 : afficher du texte sur l'écran OLED..."` → `"Afficher du texte sur l'écran OLED 128×128 intégré à la STeaMi..."`. Principe *« une fiche STeaMi se suffit à elle-même »* (cf. CONVENTIONS.md section *« Fiches indépendantes de l'éditeur »*).

### 6. Renommage i13 (#83)

- Fichier : `site/docs/inovmicro-exao/i13-morse.md` → `i13-code-morse.md`
- `id` frontmatter + catalogue : `i13-morse` → `i13-code-morse`
- `slug` : `/ressources/inovmicro-exao/i13-morse` → `/ressources/inovmicro-exao/i13-code-morse`
- Cohérence avec le dossier d'images `i13-code-morse` (créé via le template, PR #60).
- Au passage : `title` du catalogue harmonisé sur *« Envoyer des messages en code Morse avec la STeaMi »* (le H1 et le frontmatter `title` étaient déjà sur cette formulation depuis PR #72).

### 7. Template (#75)

- Placeholders au vouvoiement : *« Pour ta fiche, remplace-le »* → *« Pour votre fiche, remplacez-le »*.
- Tableau header au format 5 colonnes *« Logiciel STeaMi testé »*.
- Câble USB V1/V2.
- Version firmware exemple alignée sur 0.23.1 (au lieu de 1.23.1).

## Type de changement

- [x] Contenu (fiches)
- [x] Catalogue (resources.ts, projects.ts)
- [ ] Code
- [ ] Configuration (juste le dico cspell)

## Test plan

- [x] `npm run format:check` passe
- [x] `npm run lint:md` passe
- [x] `npm run lint:spell` passe (dico étendu : Qwiic, Sparkfun)
- [x] `npm run site:typecheck` passe
- [x] Zéro em-dash dans les `.md` de `site/docs/inovmicro-exao/`
- [x] Le renommage `i13-morse` → `i13-code-morse` n'a laissé aucune référence orpheline
- [x] La cohérence des footers de fiches avec le nom de projet `I-Novmicro #2 : Action EXAO`

## Issues fermables après merge

- #68 (decouverte-steami à jour)
- #75 (template au vouvoiement)
- #77 (summary i17 reformulé)
- #81 (label *« Logiciel STeaMi testé »* propagé)
- #83 (renommage i13)
- #84 (caractères Unicode + nom de projet) — partie retrofit faite ; reste à fermer si on considère que d'autres fiches du wiki (hors I-Novmicro) ne sont pas concernées