### PR TITLE
ci(configs): workflow d'optimisation automatique des images sur PR

### DIFF
--- a/.github/workflows/optimize-images.yml
+++ b/.github/workflows/optimize-images.yml
@@ -1,0 +1,56 @@
+name: Optimize images
+
+# Compresse automatiquement les images ajoutées ou modifiées dans une PR,
+# puis commite les versions optimisées dans la branche source et poste un
+# commentaire récapitulatif avec les gains par fichier.
+#
+# Cible : éviter d'avoir à compresser à la main avant push (cf. PR #67 et
+# #70 où plusieurs JPEG dépassaient 2 Mo).
+
+on:
+  pull_request:
+    paths:
+      - 'site/static/img/**/*.jpg'
+      - 'site/static/img/**/*.jpeg'
+      - 'site/static/img/**/*.png'
+      - 'site/static/img/**/*.gif'
+      - 'site/static/img/**/*.webp'
+
+# Annuler les runs précédents si plusieurs pushes arrivent rapidement
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  optimize:
+    name: Compress images
+    # Ne tourne pas sur les PR depuis un fork : le GITHUB_TOKEN n'a pas
+    # le droit d'écrire dans le fork. Les contributeur·rices externes
+    # devront compresser à la main, ou faire une PR depuis une branche
+    # de l'org. À reconsidérer plus tard avec un PAT si on accueille des
+    # contributions externes régulières.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - uses: calibreapp/image-actions@main
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          # compressOnly: false → l'action commit + poste un récap sur la PR.
+          compressOnly: false
+          # Les SVG sont écrits à la main dans les fiches (icônes, schémas)
+          # et ne doivent pas être recompressés.
+          ignorePaths: '**/*.svg'
+          jpegQuality: '80'
+          pngQuality: '80'
+          webpQuality: '80'
+          # Niveau 3 (max) pour les GIF animés type capture d'écran.
+          gifsicleOptimizationLevel: 3

--- a/.github/workflows/optimize-images.yml
+++ b/.github/workflows/optimize-images.yml
@@ -6,9 +6,16 @@ name: Optimize images
 #
 # Cible : éviter d'avoir à compresser à la main avant push (cf. PR #67 et
 # #70 où plusieurs JPEG dépassaient 2 Mo).
+#
+# Limitation : calibreapp/image-actions fait de la compression seule,
+# pas de redimensionnement. Pour une photo de 4032×3024 qu'on affiche
+# à 600 px, la compression seule descend à ~300 Ko ; un resize manuel
+# à 1200 px ferait mieux. Pour les rares cas où c'est nécessaire,
+# compresser avec `magick mogrify -resize 1200x` avant push reste utile.
 
 on:
   pull_request:
+    branches: [main]
     paths:
       - 'site/static/img/**/*.jpg'
       - 'site/static/img/**/*.jpeg'
@@ -41,7 +48,10 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.event.pull_request.head.ref }}
 
-      - uses: calibreapp/image-actions@main
+      # Pinné sur une release explicite plutôt que @main pour limiter
+      # le risque supply-chain et garantir la reproductibilité.
+      # Dernière release : https://github.com/calibreapp/image-actions/releases
+      - uses: calibreapp/image-actions@1.4.1
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           # compressOnly: false → l'action commit + poste un récap sur la PR.


### PR DESCRIPTION
## Résumé

Résout l'issue #73.

Au fil des PR de fiches (notamment #67 OLED et #70 capteur de lumière), plusieurs JPEG dépassaient **2 Mo** et il fallait passer un coup de `magick mogrify` à la main pendant chaque review pour ramener à des tailles raisonnables (généralement 100 à 300 Ko). Ce workflow automatise cette compression au moment du push.

## Comportement

À chaque PR ouverte ou mise à jour qui touche `site/static/img/**/*.{jpg,jpeg,png,gif,webp}` :

1. `calibreapp/image-actions` compresse les nouvelles/modifiées images
2. Commite les versions optimisées dans la branche source de la PR (avec un message qui contient `[skip ci]` pour éviter les boucles)
3. Poste un commentaire récapitulatif sur la PR avec les gains par fichier

## Paramètres

| Format | Réglage |
| --- | --- |
| JPEG / PNG / WebP | Qualité 80 |
| GIF | `gifsicleOptimizationLevel: 3` (max, utile pour les captures animées type fiche écran OLED) |
| SVG | Exclus (écrits à la main dans les fiches : icônes, schémas) |

## Garde-fous

- `if: github.event.pull_request.head.repo.full_name == github.repository` : ne tourne pas sur les PR depuis un fork (le `GITHUB_TOKEN` n'aurait pas les droits d'écrire dans le fork). Les contributeur·rices externes compresseront à la main pour l'instant. À reconsidérer si on accueille des contributions externes régulières (PAT dédié à mettre en place).
- `concurrency` + `cancel-in-progress: true` pour ne pas accumuler les runs en cas de pushes successifs.
- L'action `calibreapp/image-actions` met `[skip ci]` dans le message de son commit retour pour ne pas relancer la chaîne CI.

## Type de changement

- [ ] Contenu
- [ ] Catalogue
- [ ] Code
- [x] Configuration (CI)

## Test plan

- [x] YAML valide (`python3 -c yaml.safe_load`)
- [x] `npm run format:check` passe
- [x] `npm run lint:md` passe
- [x] Le workflow n'a aucun fichier image à traiter sur cette PR (juste un YAML), donc le job *Compress images* sera skipped sur la propre PR du workflow.

## Validation effective

La PR de fiche suivante qui pushe des images devrait déclencher le workflow et poster un commentaire. À ce moment-là on vérifiera que :

- Le commit de retour s'applique correctement à la branche source
- Le commentaire avec les gains apparaît bien
- Les SVG ne sont pas touchés

## Issue fermable après merge

#73.