### PR TITLE
ci(links): assainit le workflow lychee

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -30,10 +30,29 @@ jobs:
             'TESTING.md'
           fail: false
 
+      # Cherche s'il existe déjà une issue ouverte avec ce titre.
+      # Si oui, on passe son numéro à l'étape suivante pour mettre
+      # à jour son contenu plutôt que d'en créer une nouvelle (sinon
+      # on accumule 52 issues identiques par an, cf. #91).
+      - name: Find existing open issue
+        id: find-issue
+        if: steps.check-links.outputs.exit_code != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          issue_number=$(gh issue list \
+            --repo "${{ github.repository }}" \
+            --search '"Liens externes cassés détectés" in:title' \
+            --state open \
+            --json number \
+            --jq '.[0].number // empty')
+          echo "issue_number=${issue_number}" >> "$GITHUB_OUTPUT"
+
       - name: Update or create issue on failure
         if: steps.check-links.outputs.exit_code != '0'
         uses: peter-evans/create-issue-from-file@v5
         with:
           title: 'Liens externes cassés détectés'
           content-filepath: ./lychee/out.md
+          issue-number: ${{ steps.find-issue.outputs.issue_number }}
           labels: 'bug,liens'

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -7,18 +7,47 @@ retry_wait_time = 2
 max_retries = 2
 accept = [200, 203, 206, 429]
 
+# Permet à lychee de parser les liens root-relative (/ressources/foo,
+# /projets/bar, /img/baz) en les résolvant contre l'URL du site
+# déployé. Sans cette ligne, ~78 % des erreurs du rapport
+# hebdomadaire étaient des faux positifs "Cannot convert path ... to
+# a URI". Cf. issue #91.
+base = "https://wiki.labaixbidouille.com"
+
 # Headers pour limiter les faux positifs
 include_verbatim = true
 include_mail = false
 
-# Domaines à exclure (robots.txt strict, accès anti-bot, login requis)
+# Domaines à exclure
 exclude = [
+  # Liens internes : déjà validés par Docusaurus au build
+  # (onBrokenLinks: 'throw'). Ce workflow vise uniquement les liens
+  # externes, donc on exclut notre propre domaine après résolution
+  # via `base`.
+  "^https?://(www\\.)?wiki\\.labaixbidouille\\.com",
+
+  # Réseaux sociaux et accès login requis
   "^https://(www\\.)?linkedin\\.com",
   "^https://(www\\.)?facebook\\.com",
   "^https://(www\\.)?instagram\\.com",
   "^https://twitter\\.com",
   "^https://x\\.com",
   "^https://([a-z0-9-]+\\.)*github\\.com.*/blame/",
+
+  # Services avec protection anti-bot (Cloudflare et co.) qui
+  # retournent 403/401 aux requêtes automatisées mais fonctionnent
+  # dans un navigateur. À ne pas confondre avec les vraies 404 :
+  # n'ajouter ici que les domaines récurrents et clairement anti-bot,
+  # pas les liens qui ont peut-être déménagé.
+  "^https?://(www\\.)?leonardo\\.ai",
+  "^https?://(www\\.)?midjourney\\.com",
+  "^https?://(www\\.)?chatgpt\\.com",
+  "^https?://(www\\.)?canva\\.com",
+  "^https?://(www\\.)?microbit\\.org",
+  "^https?://(www\\.)?raspberrypi\\.com",
+  "^https?://helpx\\.adobe\\.com",
+  "^https?://(www\\.)?unsplash\\.com",
+
   "^mailto:",
   "^tel:",
 ]


### PR DESCRIPTION
## Summary

Le rapport hebdomadaire `links.yml` produisait ~78 % de faux positifs et créait une nouvelle issue chaque semaine au lieu de mettre à jour l'existante. Cf. issues #61 et #71 (2x ~250 erreurs quasi-identiques), analyse complète dans #91.

**`.lychee.toml`** :
- Ajoute `base = "https://wiki.labaixbidouille.com"` pour permettre à lychee de parser les liens root-relative (`/ressources/`, `/projets/`, `/img/`) qui retournaient *"Cannot convert path ... to a URI"* (~202 erreurs sur 258 dans #71).
- Exclut `wiki.labaixbidouille.com` après résolution : Docusaurus valide déjà ces liens au build via `onBrokenLinks: 'throw'`, ce workflow ne vise que les liens externes.
- Étend `exclude` avec les services anti-bot récurrents : `leonardo.ai`, `midjourney.com`, `chatgpt.com`, `canva.com`, `microbit.org`, `raspberrypi.com`, `helpx.adobe.com`, `unsplash.com`. Volontairement limité aux domaines **clairement anti-bot** pour ne pas masquer de vraies 404 (eur-lex, geoconfluences, cnil, ademe, etc. restent donc visibles dans le prochain rapport — c'est intentionnel).

**`.github/workflows/links.yml`** :
- Nouvelle étape `find-issue` : cherche via `gh issue list` l'issue ouverte existante avec le titre *« Liens externes cassés détectés »*.
- Passe son numéro via `issue-number` à `peter-evans/create-issue-from-file@v5`, qui met alors à jour l'issue au lieu d'en créer une nouvelle.

## Test plan

- [ ] CI verte sur la PR
- [ ] Trigger manuel du workflow `links.yml` après merge (`gh workflow run links.yml`) pour vérifier :
  - Que le rapport ne contient plus de *"Cannot convert path..."*
  - Que les sites anti-bot listés n'apparaissent plus
  - Que l'exécution met à jour l'issue #71 (ou #61) au lieu d'en créer une 3e
- [ ] Une fois le rapport propre, fermer #61 (et garder une seule issue à jour)

Refs #91, #61, #71