### PR TITLE
fix(ci): renomme base en base_url dans .lychee.toml

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -34,6 +34,12 @@ jobs:
       # Si oui, on passe son numéro à l'étape suivante pour mettre
       # à jour son contenu plutôt que d'en créer une nouvelle (sinon
       # on accumule 52 issues identiques par an, cf. #91).
+      #
+      # Tri explicite par `updatedAt` décroissant pour départager
+      # plusieurs issues homonymes (cas réel après #92 : #61 et #71
+      # existent toutes les deux). On met à jour la plus récemment
+      # touchée, ce qui converge sur une seule issue active dans le
+      # temps.
       - name: Find existing open issue
         id: find-issue
         if: steps.check-links.outputs.exit_code != '0'
@@ -44,8 +50,8 @@ jobs:
             --repo "${{ github.repository }}" \
             --search '"Liens externes cassés détectés" in:title' \
             --state open \
-            --json number \
-            --jq '.[0].number // empty')
+            --json number,updatedAt \
+            --jq 'sort_by(.updatedAt) | reverse | .[0].number // empty')
           echo "issue_number=${issue_number}" >> "$GITHUB_OUTPUT"
 
       - name: Update or create issue on failure

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -12,7 +12,10 @@ accept = [200, 203, 206, 429]
 # déployé. Sans cette ligne, ~78 % des erreurs du rapport
 # hebdomadaire étaient des faux positifs "Cannot convert path ... to
 # a URI". Cf. issue #91.
-base = "https://wiki.labaixbidouille.com"
+#
+# La clé TOML est `base_url` (pas `base`, qui crashe lychee avec
+# "unknown field").
+base_url = "https://wiki.labaixbidouille.com"
 
 # Headers pour limiter les faux positifs
 include_verbatim = true

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -26,8 +26,10 @@ exclude = [
   # Liens internes : déjà validés par Docusaurus au build
   # (onBrokenLinks: 'throw'). Ce workflow vise uniquement les liens
   # externes, donc on exclut notre propre domaine après résolution
-  # via `base`.
-  "^https?://(www\\.)?wiki\\.labaixbidouille\\.com",
+  # via `base_url`. La borne `(/|$)` après le nom de domaine évite
+  # de matcher accidentellement un sous-domaine usurpé du type
+  # `wiki.labaixbidouille.com.evil.tld`.
+  "^https?://(www\\.)?wiki\\.labaixbidouille\\.com(/|$)",
 
   # Réseaux sociaux et accès login requis
   "^https://(www\\.)?linkedin\\.com",


### PR DESCRIPTION
## Summary

Suivi de #92. Trois corrections :

**1. Clé TOML correcte pour lychee** : `base_url` (pas `base`). Le run déclenché juste après merge de #92 a crashé avec `unknown field "base"`, lychee n'a donc vérifié aucun lien.

**2. Régex domaine interne mieux ancré** (retour Copilot sur #92) : ajout de `(/|$)` après le nom de domaine pour éviter de matcher `wiki.labaixbidouille.com.evil.tld/...`.

**3. Tri explicite des issues homonymes** (retour Copilot sur #92) : `.[0].number` après `gh issue list` dépendait implicitement de l'ordre. Tri explicite par `updatedAt` décroissant : la plus récemment mise à jour gagne.

## Test plan

- [ ] Trigger manuel après merge : `gh workflow run links.yml`
- [ ] Vérifier que le run aboutit sans erreur de parse
- [ ] Vérifier que #71 est mise à jour avec un vrai rapport propre

Refs #91