### PR TITLE
fix: corriger liens externes cassés (404 et http->https)

### DIFF
--- a/site/docs/jeditrack/borne-arcade.md
+++ b/site/docs/jeditrack/borne-arcade.md
@@ -240,7 +240,7 @@ Nous avons principalement utilisé du **MDF (Medium Density Fiberboard) de 18 mm
 Approche simple mais collaborative : les jeunes ont réalisé des essais de peinture sur les prototypes avec plusieurs associations de couleurs, puis ont validé collectivement le choix final (en prenant en compte les chocs et traces potentiels). Ils ont proposé des dessins sur une zone limitée et dédiée, le reste étant recouvert de stickers sélectionnés ensemble. Bandes de chant pour protéger les tranches.
 
 :::note[Ressources stickers et finitions]
-- [https://www.buzz-arcade.com/fr/36-stickers-bornes](https://www.buzz-arcade.com/fr/36-stickers-bornes)
+- ~~[https://www.buzz-arcade.com/fr/36-stickers-bornes](https://www.buzz-arcade.com/fr/36-stickers-bornes)~~ *(page supprimée)*
 - [https://www.jdfarcade.com/stickers-borne-d-arcade/376-sticker-supreme.html](https://www.jdfarcade.com/stickers-borne-d-arcade/376-sticker-supreme.html)
 - [https://stickergameshop.com/](https://stickergameshop.com/)
 - [https://www.spreadshirt.fr/shop/papeterie/stickers/pop+culture/](https://www.spreadshirt.fr/shop/papeterie/stickers/pop+culture/)

--- a/site/docs/jeditrack/realiser-pochoirs-decoupe.md
+++ b/site/docs/jeditrack/realiser-pochoirs-decoupe.md
@@ -128,7 +128,7 @@ Les fablabs incarnent l'esprit maker : partage, collaboration, innovation ouvert
 
 **Comment trouver un fablab près de chez vous ?**
 
-Pour localiser un fablab dans votre région, plusieurs ressources fiables s'offrent à vous. Le **Réseau Français des FabLabs** ([www.fablab.fr](http://www.fablab.fr/)) propose une carte interactive très complète des fablabs français, avec des fiches détaillées indiquant les équipements disponibles, les horaires d'ouverture et les tarifs pratiqués. Au niveau international, la **Fab Foundation** ([www.fablabs.io](http://www.fablabs.io/)) maintient une cartographie mondiale des fablabs officiels respectant les critères de labellisation du MIT.
+Pour localiser un fablab dans votre région, plusieurs ressources fiables s'offrent à vous. Le **Réseau Français des FabLabs** ([www.fablab.fr](http://www.fablab.fr/)) propose une carte interactive très complète des fablabs français, avec des fiches détaillées indiquant les équipements disponibles, les horaires d'ouverture et les tarifs pratiqués. Au niveau international, la **Fab Foundation** ([www.fablabs.io](https://www.fablabs.io/)) maintient une cartographie mondiale des fablabs officiels respectant les critères de labellisation du MIT.
 
 D'autres plateformes élargissent le spectre de recherche. **Makery** ([www.makery.info](http://www.makery.info/)) offre une cartographie européenne qui inclut non seulement les fablabs mais aussi les hackerspaces et repair cafés, souvent équipés d'outils similaires. Le site **France Tiers-Lieux** (francetierslieux.fr) répertorie l'ensemble des tiers-lieux français par région et spécialités, permettant d'identifier les espaces dédiés à la fabrication numérique.
 


### PR DESCRIPTION
## Summary

Fixes #71 (partiel)

Corrige deux liens externes cassés identifiés par le lien checker :

### Changements

1. **borne-arcade.md** : Le lien `buzz-arcade.com/fr/36-stickers-bornes` retourne 404. La page a été supprimée du site. Marqué comme supprimé avec ~~strikethrough~~.

2. **realiser-pochoirs-decoupe.md** : Le lien `fablabs.io` utilisait `http://` qui retourne 404. Corrigé en `https://` qui fonctionne correctement (200 OK).

### Liens vérifiés

- `https://www.fablabs.io/` → 200 OK ✅
- `https://www.buzz-arcade.com/fr/36-stickers-bornes` → 404 ❌ (page supprimée)

---
*Generated with Auto Bounty Hunter.*