### PR TITLE
ci: bump actions vers Node 24

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Auto-assign
-        uses: pozil/auto-assign-issue@v2
+        uses: pozil/auto-assign-issue@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           assignees: nedseb,Man-BAL

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
           cache-dependency-path: site/package-lock.json
       - run: npm ci
       - run: npm run build
-      - uses: actions/upload-pages-artifact@v4
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: site/build
 

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Update or create issue on failure
         if: steps.check-links.outputs.exit_code != '0'
-        uses: peter-evans/create-issue-from-file@v5
+        uses: peter-evans/create-issue-from-file@v6
         with:
           title: 'Liens externes cassés détectés'
           content-filepath: ./lychee/out.md


### PR DESCRIPTION
## Summary

Le runner GitHub forcera Node 24 par défaut à partir du 2026-06-02 et retirera Node 20 le 2026-09-16. Trois actions étaient encore en Node 20, identifiées via les warnings de CI (cf. dernier run de #97).

| Action | Avant | Après | Fichier | Note |
|---|---|---|---|---|
| `peter-evans/create-issue-from-file` | `@v5` | `@v6` | `links.yml` | Node 24 support, aucun changement d'API |
| `actions/upload-pages-artifact` | `@v4` | `@v5` | `deploy.yml` | bump interne upload-artifact v7, ajoute input `include-hidden-files` (compat) |
| `pozil/auto-assign-issue` | `@v2` | `@v3` | `auto-assign.yml` | switch ESM + deps (compat) |

`lycheeverse/lychee-action@v2` reste sur major v2 (float prend la dernière minor, `v2.8.0`). `actions/checkout` et `actions/setup-node` étaient déjà à `@v5`. `calibreapp/image-actions@1.4.1` à jour.

## Test plan

- [ ] CI verte sur la PR (déclenche `build.yml` qui n'utilise aucune des 3 actions bumpées mais valide la syntaxe YAML)
- [ ] Trigger manuel `links.yml` post-merge pour valider le bump de `create-issue-from-file@v6`
- [ ] Vérifier qu'aucun warning Node 20 ne reste dans le prochain run de `deploy.yml`

Refs #39 §12