### PR TITLE
ci(crosslinks): lint réciprocité Let's STEAM <-> I-NOVMICRO

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Spell check
         run: npm run lint:spell
 
+      - name: Lint crosslinks Let's STEAM <-> I-NOVMICRO
+        run: npm run lint:crosslinks
+
   build:
     runs-on: ubuntu-latest
     defaults:

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -398,6 +398,20 @@ L'**attribution CC BY-SA 4.0** reste obligatoire **dans le footer** :
 _Cette fiche fait partie du projet [I-Novmicro #2 — Action EXAO](/projets/inovmicro-exao). Adaptée du projet [Let's STEAM](/projets/lets-steam) (fiche [`r1asXX-nom`](/ressources/lets-steam/r1asXX-nom)) sous licence [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/deed.fr)._
 ```
 
+### Lien croisé réciproque côté Let's STEAM
+
+Toute fiche Let's STEAM qui a une version portée dans I-NOVMICRO doit pointer vers son port via un callout `:::info[Version STeaMi / MicroPython]` placé juste après le séparateur `---` de fin de header, avant la première section de contenu :
+
+```md
+:::info[Version STeaMi / MicroPython]
+
+Cette activité existe aussi adaptée pour la carte STeaMi en MicroPython : [Titre lisible (I-Novmicro)](/ressources/inovmicro-exao/iXX-slug).
+
+:::
+```
+
+La réciprocité (footer côté I-NOVMICRO + callout côté Let's STEAM) est vérifiée par `npm run lint:crosslinks` (script [`site/scripts/lint-crosslinks.mjs`](site/scripts/lint-crosslinks.mjs)), bloquant en CI.
+
 ## Couleurs des projets
 
 | Projet           | Couleur principale |

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
       "markdownlint",
       "cspell --no-must-find-files"
     ],
-    "*.{js,jsx,ts,tsx}": [
+    "*.{js,mjs,cjs,jsx,ts,tsx}": [
       "prettier --check"
     ],
     "*.{json,css,yml,yaml}": "prettier --check"

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint:md:fix": "markdownlint --fix \"**/*.md\" --ignore-path .markdownlintignore",
     "lint:spell": "cspell --no-must-find-files",
     "lint:links": "docker run --rm -v $PWD:/input lycheeverse/lychee --config /input/.lychee.toml '/input/site/docs/**/*.md' '/input/README.md'",
+    "lint:crosslinks": "node site/scripts/lint-crosslinks.mjs",
     "site:start": "npm --prefix site start",
     "site:build": "npm --prefix site run build",
     "site:typecheck": "npm --prefix site run typecheck",

--- a/site/docs/lets-steam/r1as04-capteur-lumiere.md
+++ b/site/docs/lets-steam/r1as04-capteur-lumiere.md
@@ -47,6 +47,12 @@ sidebar_position: 4
 
 ---
 
+:::info[Version STeaMi / MicroPython]
+
+Cette activité existe aussi adaptée pour la carte STeaMi en MicroPython : [Capteur de lumière (I-Novmicro)](/ressources/inovmicro-exao/i11-capteur-lumiere).
+
+:::
+
 ## De quoi parle-t-on ?
 
 Cette fiche d'activité aborde les résistances. Une photorésistance (*Light Dependent Resistor* - LDR) est un composant utilisé pour mesurer l'intensité de la lumière.

--- a/site/docs/lets-steam/r1as06-morse.md
+++ b/site/docs/lets-steam/r1as06-morse.md
@@ -46,6 +46,12 @@ sidebar_position: 6
 
 ---
 
+:::info[Version STeaMi / MicroPython]
+
+Cette activité existe aussi adaptée pour la carte STeaMi en MicroPython : [Code Morse (I-Novmicro)](/ressources/inovmicro-exao/i13-code-morse).
+
+:::
+
 ## De quoi parle-t-on ?
 
 Le code Morse est une méthode utilisée dans les télécommunications pour coder les caractères d'un texte sous forme de séquences normalisées de deux durées de signal différentes, appelées **points** et **tirets**.

--- a/site/docs/lets-steam/r1as10-ecran-oled.md
+++ b/site/docs/lets-steam/r1as10-ecran-oled.md
@@ -43,6 +43,12 @@ sidebar_position: 10
 
 ---
 
+:::info[Version STeaMi / MicroPython]
+
+Cette activité existe aussi adaptée pour la carte STeaMi en MicroPython : [Texte sur l'écran OLED (I-Novmicro)](/ressources/inovmicro-exao/i17-texte-oled).
+
+:::
+
 ## De quoi parle-t-on ?
 
 Un écran qui vous permet d'afficher certaines informations nichées dans vos composants électroniques.

--- a/site/scripts/lint-crosslinks.mjs
+++ b/site/scripts/lint-crosslinks.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+// Vérifie l'intégrité des liens croisés Let's STEAM ↔ I-NOVMICRO.
+//
+// Source de vérité pour "telle fiche I-NOVMICRO est une adaptation de telle
+// fiche Let's STEAM" : le footer documenté dans CONVENTIONS.md §Fiches
+// indépendantes de l'éditeur :
+//
+//   _Cette fiche fait partie du projet [I-Novmicro #2 : Action EXAO]
+//   (/projets/inovmicro-exao). Adaptée du projet [Let's STEAM]
+//   (/projets/lets-steam) (fiche [`r1asXX-nom`](/ressources/lets-steam/r1asXX-nom))
+//   sous licence [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/deed.fr)._
+//
+// Sens inverse Let's STEAM -> I-NOVMICRO : tout lien
+// vers `/ressources/inovmicro-exao/<slug>` dans la fiche Let's STEAM
+// (callout `:::info[Version STeaMi / MicroPython]` recommandé en haut
+// de la fiche).
+//
+// Exécution : `node site/scripts/lint-crosslinks.mjs` depuis la racine
+// du repo, ou via `npm run lint:crosslinks`.
+//
+// Sort en code 1 si une désynchronisation est détectée (cible inexistante
+// ou lien réciproque manquant).
+
+import { readdir, readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, basename, extname } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DOCS_ROOT = join(__dirname, '..', 'docs');
+const INOVMICRO_DIR = join(DOCS_ROOT, 'inovmicro-exao');
+const LETSSTEAM_DIR = join(DOCS_ROOT, 'lets-steam');
+
+// Capture le slug Let's STEAM cité par le footer "Adaptée du projet [Let's STEAM]
+// (...) (fiche [`r1asXX-nom`](/ressources/lets-steam/r1asXX-nom))". Restreint au
+// footer pour ne pas confondre avec d'autres mentions en "voir aussi".
+const ADAPTED_FROM_RE =
+  /Adaptée du projet \[Let's STEAM\]\([^)]+\) \(fiche \[`[^`]+`\]\(\/ressources\/lets-steam\/([a-z0-9][a-z0-9-]*)\)/;
+
+// Capture tout lien Let's STEAM -> I-NOVMICRO dans le corps de la fiche.
+const INOVMICRO_LINK_RE = /\/ressources\/inovmicro-exao\/([a-z0-9][a-z0-9-]*)/g;
+
+async function listFiches(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  return entries
+    .filter((e) => e.isFile() && e.name.endsWith('.md') && !e.name.startsWith('_'))
+    .map((e) => join(dir, e.name));
+}
+
+const slugOf = (file) => basename(file, extname(file));
+
+async function main() {
+  const errors = [];
+  const [inovFiles, letsFiles] = await Promise.all([
+    listFiches(INOVMICRO_DIR),
+    listFiches(LETSSTEAM_DIR),
+  ]);
+  const letsSlugs = new Set(letsFiles.map(slugOf));
+  const inovSlugs = new Set(inovFiles.map(slugOf));
+
+  // Map: slug I-NOVMICRO -> slug Let's STEAM source (depuis le footer "Adaptée du projet").
+  // Une fiche I-NOVMICRO sans match n'est pas un port (ex. decouverte-steami, depannage).
+  const portToSource = new Map();
+  for (const f of inovFiles) {
+    const text = await readFile(f, 'utf8');
+    const m = text.match(ADAPTED_FROM_RE);
+    if (m) portToSource.set(slugOf(f), m[1]);
+  }
+
+  // Map: slug Let's STEAM -> set de slugs I-NOVMICRO référencés dans le corps.
+  const letsToInov = new Map();
+  for (const f of letsFiles) {
+    const text = await readFile(f, 'utf8');
+    const refs = new Set([...text.matchAll(INOVMICRO_LINK_RE)].map((m) => m[1]));
+    letsToInov.set(slugOf(f), refs);
+  }
+
+  // Check 1 : la source Let's STEAM citée par chaque port existe.
+  for (const [inovSlug, letsTarget] of portToSource) {
+    if (!letsSlugs.has(letsTarget)) {
+      errors.push(
+        `${inovSlug}.md : footer pointe vers /ressources/lets-steam/${letsTarget} qui n'existe pas`,
+      );
+    }
+  }
+
+  // Check 2 : chaque cible I-NOVMICRO citée par une fiche Let's STEAM existe.
+  for (const [letsSlug, refs] of letsToInov) {
+    for (const target of refs) {
+      if (!inovSlugs.has(target)) {
+        errors.push(
+          `${letsSlug}.md : lien vers /ressources/inovmicro-exao/${target} qui n'existe pas`,
+        );
+      }
+    }
+  }
+
+  // Check 3 : tout port a son lien réciproque côté Let's STEAM.
+  for (const [inovSlug, letsTarget] of portToSource) {
+    const reverse = letsToInov.get(letsTarget) ?? new Set();
+    if (!reverse.has(inovSlug)) {
+      errors.push(
+        `lien réciproque manquant : ${letsTarget}.md (Let's STEAM) devrait pointer vers /ressources/inovmicro-exao/${inovSlug}`,
+      );
+    }
+  }
+
+  // Check 4 : tout lien Let's STEAM -> I-NOVMICRO a son footer "Adaptée du projet" côté I-NOVMICRO.
+  for (const [letsSlug, inovRefs] of letsToInov) {
+    for (const inovTarget of inovRefs) {
+      const expectedSource = portToSource.get(inovTarget);
+      if (expectedSource !== letsSlug) {
+        errors.push(
+          `lien réciproque orphelin : ${letsSlug}.md (Let's STEAM) pointe vers ${inovTarget} mais ${inovTarget}.md ne le déclare pas comme source dans son footer "Adaptée du projet"`,
+        );
+      }
+    }
+  }
+
+  if (errors.length > 0) {
+    console.error(`Crosslinks Let's STEAM <-> I-NOVMICRO : ${errors.length} problème(s)`);
+    for (const e of errors) console.error(`  - ${e}`);
+    process.exit(1);
+  }
+
+  console.log(
+    `Crosslinks Let's STEAM <-> I-NOVMICRO : ${portToSource.size} port(s), ${inovFiles.length} fiches I-NOVMICRO, ${letsFiles.length} fiches Let's STEAM. OK.`,
+  );
+}
+
+main().catch((err) => {
+  console.error('Erreur inattendue :', err);
+  process.exit(1);
+});

--- a/site/scripts/lint-crosslinks.mjs
+++ b/site/scripts/lint-crosslinks.mjs
@@ -41,8 +41,7 @@ const ADAPTED_FROM_RE =
 // callout (cf. CONVENTIONS.md §Lien croisé réciproque côté Let's STEAM) :
 // une mention de l'URL en passant dans le corps ne suffit pas, on veut le
 // callout dédié pour la visibilité côté lecteur.
-const VERSION_STEAMI_CALLOUT_RE =
-  /:::info\[Version STeaMi \/ MicroPython\]\s*([\s\S]*?):::/g;
+const VERSION_STEAMI_CALLOUT_RE = /:::info\[Version STeaMi \/ MicroPython\]\s*([\s\S]*?):::/g;
 const INOVMICRO_LINK_RE = /\/ressources\/inovmicro-exao\/([a-z0-9][a-z0-9-]*)/g;
 
 async function listFiches(dir) {

--- a/site/scripts/lint-crosslinks.mjs
+++ b/site/scripts/lint-crosslinks.mjs
@@ -36,7 +36,13 @@ const LETSSTEAM_DIR = join(DOCS_ROOT, 'lets-steam');
 const ADAPTED_FROM_RE =
   /Adaptée du projet \[Let's STEAM\]\([^)]+\) \(fiche \[`[^`]+`\]\(\/ressources\/lets-steam\/([a-z0-9][a-z0-9-]*)\)/;
 
-// Capture tout lien Let's STEAM -> I-NOVMICRO dans le corps de la fiche.
+// Capture les liens I-NOVMICRO uniquement à l'intérieur d'un callout
+// `:::info[Version STeaMi / MicroPython] ... :::`. La convention impose ce
+// callout (cf. CONVENTIONS.md §Lien croisé réciproque côté Let's STEAM) :
+// une mention de l'URL en passant dans le corps ne suffit pas, on veut le
+// callout dédié pour la visibilité côté lecteur.
+const VERSION_STEAMI_CALLOUT_RE =
+  /:::info\[Version STeaMi \/ MicroPython\]\s*([\s\S]*?):::/g;
 const INOVMICRO_LINK_RE = /\/ressources\/inovmicro-exao\/([a-z0-9][a-z0-9-]*)/g;
 
 async function listFiches(dir) {
@@ -66,11 +72,17 @@ async function main() {
     if (m) portToSource.set(slugOf(f), m[1]);
   }
 
-  // Map: slug Let's STEAM -> set de slugs I-NOVMICRO référencés dans le corps.
+  // Map: slug Let's STEAM -> set de slugs I-NOVMICRO référencés à l'intérieur
+  // du callout `:::info[Version STeaMi / MicroPython] ... :::`.
   const letsToInov = new Map();
   for (const f of letsFiles) {
     const text = await readFile(f, 'utf8');
-    const refs = new Set([...text.matchAll(INOVMICRO_LINK_RE)].map((m) => m[1]));
+    const refs = new Set();
+    for (const callout of text.matchAll(VERSION_STEAMI_CALLOUT_RE)) {
+      for (const link of callout[1].matchAll(INOVMICRO_LINK_RE)) {
+        refs.add(link[1]);
+      }
+    }
     letsToInov.set(slugOf(f), refs);
   }
 


### PR DESCRIPTION
## Summary

Script de lint qui vérifie la réciprocité des liens croisés entre les fiches Let's STEAM et leurs ports I-NOVMICRO.

**Détection** : le footer `Adaptée du projet [Let's STEAM] (fiche [...](...))` côté I-NOVMICRO est la source de vérité pour "telle fiche est un port de telle autre" (convention `CONVENTIONS.md` §Une fiche STeaMi se suffit à elle-même).

**Quatre checks** :
1. Tout port I-NOVMICRO cite une fiche Let's STEAM qui existe.
2. Tout lien Let's STEAM → `/ressources/inovmicro-exao/...` cible une fiche existante.
3. Chaque port a son lien réciproque côté Let's STEAM.
4. Tout lien côté Let's STEAM est cohérent avec un footer qui déclare cette fiche comme source.

**Wiring** :
- `site/scripts/lint-crosslinks.mjs` : Node ESM, pas de dépendance ajoutée (pas de `tsx`, pas de TypeScript).
- `npm run lint:crosslinks` au root.
- Étape ajoutée dans le job `lint` de [`build.yml`](.github/workflows/build.yml), bloquante en PR.
- Convention du callout côté Let's STEAM documentée dans `CONVENTIONS.md`.

**Application rétroactive** : les 3 ports existants n'avaient pas leur lien réciproque. Callouts ajoutés sur :
- `r1as04-capteur-lumiere.md` → `i11-capteur-lumiere`
- `r1as06-morse.md` → `i13-code-morse`
- `r1as10-ecran-oled.md` → `i17-texte-oled`

## Test plan

- [x] `node site/scripts/lint-crosslinks.mjs` au vert (`3 port(s), 6 fiches I-NOVMICRO, 15 fiches Let's STEAM, OK`)
- [x] Lint a bien détecté les 3 désynchronisations avant correction
- [x] `npm run site:build` OK
- [x] `npm run lint:spell` OK (200 fichiers, 0 issue)
- [ ] CI verte sur la PR

Closes #26