### PR TITLE
fix(ci): retours Copilot sur optimize-images (diff + pathspec)

### DIFF
--- a/.github/workflows/optimize-images.yml
+++ b/.github/workflows/optimize-images.yml
@@ -62,12 +62,19 @@ jobs:
           BASE: ${{ github.event.pull_request.base.sha }}
           HEAD: ${{ github.event.pull_request.head.sha }}
         run: |
-          changed=$(git diff --name-only --diff-filter=AM "$BASE" "$HEAD" -- \
-            'site/static/img/**/*.jpg' \
-            'site/static/img/**/*.jpeg' \
-            'site/static/img/**/*.png' \
-            'site/static/img/**/*.gif' \
-            'site/static/img/**/*.webp')
+          # `fetch-depth: 0` au checkout couvre normalement tous les objets,
+          # mais base.sha peut ne plus être atteignable s'il a été
+          # force-pushé après la création de la PR. On le re-fetche
+          # explicitement pour fiabiliser le diff (le `|| true` évite de
+          # planter le step si le fetch est déjà à jour).
+          git fetch --quiet --depth=1 origin "$BASE" || true
+          # Filtrage post-hoc via `grep` plutôt que pathspecs `**` : les
+          # pathspecs git n'interprètent pas `**` comme un globstar (le `*`
+          # par défaut matche déjà `/` mais la sémantique reste différente
+          # du filtre `paths:` au top du workflow). `grep` est plus lisible
+          # et a la même intention que le filtre de déclencheur.
+          changed=$(git diff --name-only --diff-filter=AM "$BASE" "$HEAD" \
+            | grep -E '^site/static/img/.*\.(jpg|jpeg|png|gif|webp)$' || true)
           if [ -z "$changed" ]; then
             echo "Aucune image ajoutée ou modifiée en contenu (que des renames). Skip."
             echo "skip=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/optimize-images.yml
+++ b/.github/workflows/optimize-images.yml
@@ -64,17 +64,25 @@ jobs:
         run: |
           # `fetch-depth: 0` au checkout couvre normalement tous les objets,
           # mais base.sha peut ne plus être atteignable s'il a été
-          # force-pushé après la création de la PR. On le re-fetche
-          # explicitement pour fiabiliser le diff (le `|| true` évite de
-          # planter le step si le fetch est déjà à jour).
-          git fetch --quiet --depth=1 origin "$BASE" || true
-          # Filtrage post-hoc via `grep` plutôt que pathspecs `**` : les
-          # pathspecs git n'interprètent pas `**` comme un globstar (le `*`
-          # par défaut matche déjà `/` mais la sémantique reste différente
-          # du filtre `paths:` au top du workflow). `grep` est plus lisible
-          # et a la même intention que le filtre de déclencheur.
+          # force-pushé après la création de la PR. On vérifie sa présence
+          # locale et on le re-fetche uniquement si nécessaire, en
+          # échouant franchement si le fetch ne récupère rien (sinon le
+          # `git diff` qui suit donne des résultats incohérents et
+          # silencieux).
+          if ! git rev-parse --verify --quiet "$BASE^{commit}" > /dev/null; then
+            echo "Base SHA $BASE absent du clone local, fetch défensif..."
+            if ! git fetch --depth=1 origin "$BASE"; then
+              echo "::error::Impossible de récupérer la base SHA $BASE (force-push ?). Diff impossible."
+              exit 1
+            fi
+          fi
+          # Filtrage post-hoc plutôt que pathspecs `**` : les pathspecs git
+          # n'interprètent pas `**` comme un globstar, la sémantique reste
+          # différente du filtre `paths:` au top du workflow. `awk` plutôt
+          # que `grep` pour éviter le quirk "exit 1 quand pas de match"
+          # qui forcerait un `|| true` masquant aussi les vraies erreurs.
           changed=$(git diff --name-only --diff-filter=AM "$BASE" "$HEAD" \
-            | grep -E '^site/static/img/.*\.(jpg|jpeg|png|gif|webp)$' || true)
+            | awk '/^site\/static\/img\/.*\.(jpg|jpeg|png|gif|webp)$/')
           if [ -z "$changed" ]; then
             echo "Aucune image ajoutée ou modifiée en contenu (que des renames). Skip."
             echo "skip=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Suite des retours Copilot post-merge sur #103.

**1. Diff base/head fiabilisé**
`fetch-depth: 0` au checkout couvre l'historique visible, mais `base.sha` peut ne plus être atteignable si la base a été force-pushée. Le `git diff` planterait alors avec `fatal: bad object`. Ajout d'un `git fetch --depth=1 origin "$BASE"` défensif (avec `|| true` pour ne pas planter le step si le fetch est inutile).

**2. Pathspec lisible**
Les pathspecs `site/static/img/**/*.jpg` utilisaient `**` qui n'est pas un globstar en git (le `*` par défaut matche déjà `/`, ça marchait par effet de bord). Remplacement par un filtrage `grep -E` post-`git diff`, avec la même intention que le filtre `paths:` du déclencheur :

```bash
git diff --name-only --diff-filter=AM "$BASE" "$HEAD" \
  | grep -E '^site/static/img/.*\.(jpg|jpeg|png|gif|webp)$'
```

Refs #1