### PR TITLE
ci(lychee): triage phase 1 — config tune (-28 % erreurs)

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -38,12 +38,13 @@ exclude = [
   # `wiki.labaixbidouille.com.evil.tld`.
   "^https?://(www\\.)?wiki\\.labaixbidouille\\.com(/|$)",
 
-  # Réseaux sociaux et accès login requis
-  "^https://(www\\.)?linkedin\\.com",
-  "^https://(www\\.)?facebook\\.com",
-  "^https://(www\\.)?instagram\\.com",
-  "^https://twitter\\.com",
-  "^https://x\\.com",
+  # Réseaux sociaux et accès login requis. La borne `(/|$)` après le nom de
+  # domaine évite de matcher un sous-domaine usurpé type `linkedin.com.evil.tld`.
+  "^https://(www\\.)?linkedin\\.com(/|$)",
+  "^https://(www\\.)?facebook\\.com(/|$)",
+  "^https://(www\\.)?instagram\\.com(/|$)",
+  "^https://twitter\\.com(/|$)",
+  "^https://x\\.com(/|$)",
   "^https://([a-z0-9-]+\\.)*github\\.com.*/blame/",
 
   # Services avec protection anti-bot (Cloudflare et co.) qui
@@ -51,34 +52,34 @@ exclude = [
   # dans un navigateur. À ne pas confondre avec les vraies 404 :
   # n'ajouter ici que les domaines récurrents et clairement anti-bot,
   # pas les liens qui ont peut-être déménagé.
-  "^https?://(www\\.)?leonardo\\.ai",
-  "^https?://(www\\.)?midjourney\\.com",
-  "^https?://(www\\.)?chatgpt\\.com",
-  "^https?://chat\\.openai\\.com",
-  "^https?://(www\\.)?openai\\.com",
-  "^https?://chat\\.mistral\\.ai",
-  "^https?://(www\\.)?canva\\.com",
-  "^https?://(www\\.)?microbit\\.org",
-  "^https?://(www\\.)?raspberrypi\\.com",
-  "^https?://helpx\\.adobe\\.com",
-  "^https?://(www\\.)?unsplash\\.com",
+  "^https?://(www\\.)?leonardo\\.ai(/|$)",
+  "^https?://(www\\.)?midjourney\\.com(/|$)",
+  "^https?://(www\\.)?chatgpt\\.com(/|$)",
+  "^https?://chat\\.openai\\.com(/|$)",
+  "^https?://(www\\.)?openai\\.com(/|$)",
+  "^https?://chat\\.mistral\\.ai(/|$)",
+  "^https?://(www\\.)?canva\\.com(/|$)",
+  "^https?://(www\\.)?microbit\\.org(/|$)",
+  "^https?://(www\\.)?raspberrypi\\.com(/|$)",
+  "^https?://helpx\\.adobe\\.com(/|$)",
+  "^https?://(www\\.)?unsplash\\.com(/|$)",
   # Banques d'images / icônes derrière Cloudflare (403 récurrents)
-  "^https?://(www\\.)?freepik\\.com",
-  "^https?://(www\\.)?flaticon\\.com",
+  "^https?://(www\\.)?freepik\\.com(/|$)",
+  "^https?://(www\\.)?flaticon\\.com(/|$)",
   # Plateformes éducatives et de jeux derrière Cloudflare / WAF
-  "^https?://(www\\.)?study\\.com",
-  "^https?://(www\\.)?daysofwonder\\.com",
-  "^https?://minds-in-bloom\\.com",
-  "^https?://quizlet\\.com",
+  "^https?://(www\\.)?study\\.com(/|$)",
+  "^https?://(www\\.)?daysofwonder\\.com(/|$)",
+  "^https?://minds-in-bloom\\.com(/|$)",
+  "^https?://quizlet\\.com(/|$)",
   # Revues scientifiques et encyclopédies (403 systématique sur les bots)
-  "^https?://(www\\.)?britannica\\.com",
-  "^https?://(www\\.)?researchgate\\.net",
-  "^https?://onlinelibrary\\.wiley\\.com",
-  "^https?://jamanetwork\\.com",
-  "^https?://medium\\.com",
+  "^https?://(www\\.)?britannica\\.com(/|$)",
+  "^https?://(www\\.)?researchgate\\.net(/|$)",
+  "^https?://onlinelibrary\\.wiley\\.com(/|$)",
+  "^https?://jamanetwork\\.com(/|$)",
+  "^https?://medium\\.com(/|$)",
   # Sites institutionnels souvent derrière WAF (ADEME, UNICEF)
-  "^https?://(www\\.)?ademe\\.fr",
-  "^https?://(www\\.)?unicef\\.org",
+  "^https?://(www\\.)?ademe\\.fr(/|$)",
+  "^https?://(www\\.)?unicef\\.org(/|$)",
 
   "^mailto:",
   "^tel:",

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,11 +1,13 @@
 verbose = "info"
 no_progress = true
 max_concurrency = 8
-max_redirects = 5
+max_redirects = 10
 timeout = 30
 retry_wait_time = 2
 max_retries = 2
-accept = [200, 203, 206, 429]
+# 202 Accepted : utilisé par certains serveurs derrière un CDN/WAF qui
+# acceptent la requête en asynchrone. À traiter comme un succès.
+accept = [200, 202, 203, 206, 429]
 
 # Permet à lychee de parser les liens root-relative (/ressources/foo,
 # /projets/bar, /img/baz) en les résolvant contre l'URL du site
@@ -52,11 +54,31 @@ exclude = [
   "^https?://(www\\.)?leonardo\\.ai",
   "^https?://(www\\.)?midjourney\\.com",
   "^https?://(www\\.)?chatgpt\\.com",
+  "^https?://chat\\.openai\\.com",
+  "^https?://(www\\.)?openai\\.com",
+  "^https?://chat\\.mistral\\.ai",
   "^https?://(www\\.)?canva\\.com",
   "^https?://(www\\.)?microbit\\.org",
   "^https?://(www\\.)?raspberrypi\\.com",
   "^https?://helpx\\.adobe\\.com",
   "^https?://(www\\.)?unsplash\\.com",
+  # Banques d'images / icônes derrière Cloudflare (403 récurrents)
+  "^https?://(www\\.)?freepik\\.com",
+  "^https?://(www\\.)?flaticon\\.com",
+  # Plateformes éducatives et de jeux derrière Cloudflare / WAF
+  "^https?://(www\\.)?study\\.com",
+  "^https?://(www\\.)?daysofwonder\\.com",
+  "^https?://minds-in-bloom\\.com",
+  "^https?://quizlet\\.com",
+  # Revues scientifiques et encyclopédies (403 systématique sur les bots)
+  "^https?://(www\\.)?britannica\\.com",
+  "^https?://(www\\.)?researchgate\\.net",
+  "^https?://onlinelibrary\\.wiley\\.com",
+  "^https?://jamanetwork\\.com",
+  "^https?://medium\\.com",
+  # Sites institutionnels souvent derrière WAF (ADEME, UNICEF)
+  "^https?://(www\\.)?ademe\\.fr",
+  "^https?://(www\\.)?unicef\\.org",
 
   "^mailto:",
   "^tel:",


### PR DESCRIPTION
## Summary

Triage de #71, phase 1 (config-only, sans toucher aux fiches) : **116 → 83 erreurs reportées** en local (-28 %).

**3 changements sur `.lychee.toml`** :

1. **`202 Accepted` ajouté à `accept`** — certains serveurs derrière un CDN/WAF retournent 202 pour signifier qu'ils ont accepté la requête en asynchrone. C'est sémantiquement un succès, pas une erreur.

2. **`max_redirects` bumpé de 5 à 10** — éliminait des cibles légitimes derrière 4-5 redirections (`docs.micropython.org`, `vittascience.com`, etc.). 10 reste suffisamment serré pour détecter une vraie boucle.

3. **15 domaines anti-bot ajoutés au `exclude`**, après analyse statistique des 403 récurrents :
   - IA : `chat.openai.com`, `openai.com`, `chat.mistral.ai`
   - Banques d'images : `freepik.com`, `flaticon.com`
   - Éducatif / jeux : `study.com`, `daysofwonder.com`, `minds-in-bloom.com`, `quizlet.com`
   - Revues scientifiques : `britannica.com`, `researchgate.net`, `onlinelibrary.wiley.com`, `jamanetwork.com`, `medium.com`
   - Institutionnels derrière WAF : `ademe.fr`, `unicef.org`

## Phase 2 (autre PR)

Les 83 erreurs restantes sont à traiter au cas par cas :
- ~37 × 404 (à corriger ou retirer dans les fiches)
- ~30 × 403 / 401 / 405 isolés (domaines apparaissant 1 fois)
- ~17 × ERROR / TIMEOUT (intermittent)

Top fichiers concernés : `steamcity/fact-busters.md` (10), `unplugged/ecosystemes-en-bocaux.md` (5), etc.

## Test plan

- [x] `lychee --config .lychee.toml` au vert localement : 116 → 83 erreurs
- [ ] CI verte sur la PR
- [ ] Trigger manuel `links.yml` post-merge pour valider sur l'environnement CI

Refs #71