### PR TITLE
ci(links): vérification anti-bot via Playwright stealth (local d'abord)

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -148,14 +148,22 @@ Lychee ne distingue pas une vraie 404 d'une 403 anti-bot (Cloudflare Turnstile, 
 Usage typique :
 
 ```bash
-# 1. Lychee en mode JSON
+# 1. Lychee en mode JSON. Soit avec le binaire natif :
 lychee --config .lychee.toml --format json --output /tmp/lychee.json site/docs/**/*.md
+
+# Soit via Docker (cf. `npm run lint:links` plus haut) :
+docker run --rm -v "$PWD:/input" lycheeverse/lychee \
+  --config /input/.lychee.toml --format json --output /input/lychee.json \
+  '/input/site/docs/**/*.md'
 
 # 2. Filtrage navigateur
 npm run verify-broken-links -- /tmp/lychee.json --report=/tmp/report.md
 ```
 
-Pré-requis : `npx playwright install chromium` (~150 Mo, à faire une fois).
+Pré-requis :
+
+- Lychee installé en binaire (`cargo install lychee` ou `brew install lychee`) OU Docker (la commande `lint:links` du `package.json` utilise déjà Docker).
+- Chromium pour Playwright : `npx playwright install chromium` (~150 Mo, à faire une fois). Le package `playwright` n'auto-télécharge **pas** les navigateurs depuis la v1.40, donc cette étape reste manuelle.
 
 L'intégration de ce filtre dans le workflow `links.yml` est suivie en PR séparée.
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -141,6 +141,24 @@ Vérification des liens externes via [Lychee](https://github.com/lycheeverse/lyc
 
 Localement : `npm run lint:links` (Docker requis).
 
+### Vérification anti-bot via Playwright (`npm run verify-broken-links`)
+
+Lychee ne distingue pas une vraie 404 d'une 403 anti-bot (Cloudflare Turnstile, etc.). Le script [`site/scripts/verify-broken-links.mjs`](site/scripts/verify-broken-links.mjs) rejoue les erreurs lychee via un Chromium headless avec plugin stealth (`puppeteer-extra-plugin-stealth`) pour écarter les faux positifs. Seules les URLs où lychee **et** le navigateur échouent sont conservées comme cassures à corriger.
+
+Usage typique :
+
+```bash
+# 1. Lychee en mode JSON
+lychee --config .lychee.toml --format json --output /tmp/lychee.json site/docs/**/*.md
+
+# 2. Filtrage navigateur
+npm run verify-broken-links -- /tmp/lychee.json --report=/tmp/report.md
+```
+
+Pré-requis : `npx playwright install chromium` (~150 Mo, à faire une fois).
+
+L'intégration de ce filtre dans le workflow `links.yml` est suivie en PR séparée.
+
 ### Workflow `auto-assign.yml`
 
 À l'ouverture d'une issue ou PR, assigne automatiquement un mainteneur.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,10 @@
         "husky": "^9.1.7",
         "lint-staged": "^15.2.10",
         "markdownlint-cli": "^0.43.0",
+        "playwright": "^1.60.0",
+        "playwright-extra": "^4.3.6",
         "prettier": "^3.3.3",
+        "puppeteer-extra-plugin-stealth": "^2.11.2",
         "validate-branch-name": "^1.3.1"
       }
     },
@@ -944,6 +947,23 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "25.6.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
@@ -1028,6 +1048,16 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/array-ify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
@@ -1041,6 +1071,24 @@
       "integrity": "sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
     },
     "node_modules/braces": {
       "version": "3.0.3",
@@ -1260,6 +1308,23 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/clone-deep": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
+      "integrity": "sha512-we+NuQo2DHhSl+DP6jlUiAhyAjBQrYnpOk15rN6c6JSPScjiCLh8IbSU+VTcph6YS3o7mASE8a0+gbZ7ChLpgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "for-own": "^0.1.3",
+        "is-plain-object": "^2.0.1",
+        "kind-of": "^3.0.2",
+        "lazy-cache": "^1.0.3",
+        "shallow-clone": "^0.1.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1331,6 +1396,13 @@
         "array-ify": "^1.0.0",
         "dot-prop": "^5.1.0"
       }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/conventional-changelog-angular": {
       "version": "7.0.0",
@@ -1673,6 +1745,16 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/dot-prop": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
@@ -1928,6 +2010,29 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/for-own": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+      "integrity": "sha512-SKmowqGTJoPzLO1T0BBJpkfp3EMacCMOuH40hOUbrbzElVktk4DioXVM99QkLCyKoiuOmyjgcWMpVz2xjE7LZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "for-in": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -1943,6 +2048,43 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -2288,6 +2430,25 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/ini": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.1.tgz",
@@ -2302,6 +2463,13 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true,
       "license": "MIT"
     },
@@ -2337,6 +2505,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
@@ -2368,6 +2546,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-stream": {
@@ -2415,6 +2606,16 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/jackspeak": {
       "version": "4.2.3",
@@ -2490,6 +2691,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "node_modules/jsonparse": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
@@ -2535,6 +2749,29 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/lazy-cache": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "integrity": "sha512-RE2g0b5VGZsOCFOCgP7omTRYFqydmZkBwl5oNnQ1lDYC57uyO9KqNnNVxT7COSHTxrRCWVcAVOcbjk+tvh/rgQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/lilconfig": {
@@ -2874,6 +3111,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/merge-deep": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/merge-deep/-/merge-deep-3.0.3.tgz",
+      "integrity": "sha512-qtmzAS6t6grwEkNrunqTBdn0qKwFgNWvlxUbAV8es9M7Ot1EbyApytCnvE0jALPa46ZpKDUo527kKiaWplmlFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "arr-union": "^3.1.0",
+        "clone-deep": "^0.2.4",
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -2970,6 +3222,30 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mixin-object": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
+      "integrity": "sha512-ALGF1Jt9ouehcaXaHhn6t1yGWRqGaHkPFndtFVHfZXOvkIZ/yoGaSi0AHVTafb3ZBGg4dr/bDwnaEKqCXzchMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "for-in": "^0.1.3",
+        "is-extendable": "^0.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/mixin-object/node_modules/for-in": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
+      "integrity": "sha512-F0to7vbBSHP8E3l6dCjxNOLuSFAACIxFy3UehTUlG7svlXi37HHsDkyVcHo0Pq8QwrE+pXvWSVX3ZT1T9wAZ9g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -3042,6 +3318,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/onetime": {
@@ -3151,6 +3437,16 @@
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -3208,7 +3504,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3227,6 +3522,65 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright-extra": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/playwright-extra/-/playwright-extra-4.3.6.tgz",
+      "integrity": "sha512-q2rVtcE8V8K3vPVF1zny4pvwZveHLH8KBuVU2MoE3Jw4OKVoBWsHI9CH9zPydovHHOCDxjGN2Vg+2m644q3ijA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "playwright": "*",
+        "playwright-core": "*"
+      },
+      "peerDependenciesMeta": {
+        "playwright": {
+          "optional": true
+        },
+        "playwright-core": {
+          "optional": true
+        }
       }
     },
     "node_modules/prettier": {
@@ -3253,6 +3607,116 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/puppeteer-extra-plugin": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/puppeteer-extra-plugin/-/puppeteer-extra-plugin-3.2.3.tgz",
+      "integrity": "sha512-6RNy0e6pH8vaS3akPIKGg28xcryKscczt4wIl0ePciZENGE2yoaQJNd17UiEbdmh5/6WW6dPcfRWT9lxBwCi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.1.0",
+        "debug": "^4.1.1",
+        "merge-deep": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=9.11.2"
+      },
+      "peerDependencies": {
+        "playwright-extra": "*",
+        "puppeteer-extra": "*"
+      },
+      "peerDependenciesMeta": {
+        "playwright-extra": {
+          "optional": true
+        },
+        "puppeteer-extra": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/puppeteer-extra-plugin-stealth": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/puppeteer-extra-plugin-stealth/-/puppeteer-extra-plugin-stealth-2.11.2.tgz",
+      "integrity": "sha512-bUemM5XmTj9i2ZerBzsk2AN5is0wHMNE6K0hXBzBXOzP5m5G3Wl0RHhiqKeHToe/uIH8AoZiGhc1tCkLZQPKTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "puppeteer-extra-plugin": "^3.2.3",
+        "puppeteer-extra-plugin-user-preferences": "^2.4.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "playwright-extra": "*",
+        "puppeteer-extra": "*"
+      },
+      "peerDependenciesMeta": {
+        "playwright-extra": {
+          "optional": true
+        },
+        "puppeteer-extra": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/puppeteer-extra-plugin-user-data-dir": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-extra-plugin-user-data-dir/-/puppeteer-extra-plugin-user-data-dir-2.4.1.tgz",
+      "integrity": "sha512-kH1GnCcqEDoBXO7epAse4TBPJh9tEpVEK/vkedKfjOVOhZAvLkHGc9swMs5ChrJbRnf8Hdpug6TJlEuimXNQ+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "fs-extra": "^10.0.0",
+        "puppeteer-extra-plugin": "^3.2.3",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "playwright-extra": "*",
+        "puppeteer-extra": "*"
+      },
+      "peerDependenciesMeta": {
+        "playwright-extra": {
+          "optional": true
+        },
+        "puppeteer-extra": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/puppeteer-extra-plugin-user-preferences": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-extra-plugin-user-preferences/-/puppeteer-extra-plugin-user-preferences-2.4.1.tgz",
+      "integrity": "sha512-i1oAZxRbc1bk8MZufKCruCEC3CCafO9RKMkkodZltI4OqibLFXF3tj6HZ4LZ9C5vCXZjYcDWazgtY69mnmrQ9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "deepmerge": "^4.2.2",
+        "puppeteer-extra-plugin": "^3.2.3",
+        "puppeteer-extra-plugin-user-data-dir": "^2.4.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "playwright-extra": "*",
+        "puppeteer-extra": "*"
+      },
+      "peerDependenciesMeta": {
+        "playwright-extra": {
+          "optional": true
+        },
+        "puppeteer-extra": {
+          "optional": true
+        }
       }
     },
     "node_modules/read-pkg": {
@@ -3443,6 +3907,58 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/run-con": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/run-con/-/run-con-1.3.2.tgz",
@@ -3470,6 +3986,45 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/shallow-clone": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-0.1.2.tgz",
+      "integrity": "sha512-J1zdXCky5GmNnuauESROVu31MQSnLoYvlyEn6j2Ztk6Q5EHFIhxkMhYcv6vuDzl2XEzoRr856QwzMgWM/TmZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.1",
+        "kind-of": "^2.0.1",
+        "lazy-cache": "^0.2.3",
+        "mixin-object": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/shallow-clone/node_modules/kind-of": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+      "integrity": "sha512-0u8i1NZ/mg0b+W3MGGw5I7+6Eib2nx72S/QvXa0hYjEkjTknYmEYQJwGu3mLC0BrhtJjtQafTkyRUQ75Kx0LVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-buffer": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/shallow-clone/node_modules/lazy-cache": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+      "integrity": "sha512-gkX52wvU/R8DVMMt78ATVPFMJqfW8FPz1GZ1sVHBVQHmu/WvhIWE4cE1GBzhJNFicDeYhnwp6Rl35BcAIM3YOQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/shebang-command": {
@@ -3796,6 +4351,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -3916,6 +4481,13 @@
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/xdg-basedir": {
       "version": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint:spell": "cspell --no-must-find-files",
     "lint:links": "docker run --rm -v $PWD:/input lycheeverse/lychee --config /input/.lychee.toml '/input/site/docs/**/*.md' '/input/README.md'",
     "lint:crosslinks": "node site/scripts/lint-crosslinks.mjs",
+    "verify-broken-links": "node site/scripts/verify-broken-links.mjs",
     "site:start": "npm --prefix site start",
     "site:build": "npm --prefix site run build",
     "site:typecheck": "npm --prefix site run typecheck",
@@ -26,7 +27,10 @@
     "husky": "^9.1.7",
     "lint-staged": "^15.2.10",
     "markdownlint-cli": "^0.43.0",
+    "playwright": "^1.60.0",
+    "playwright-extra": "^4.3.6",
     "prettier": "^3.3.3",
+    "puppeteer-extra-plugin-stealth": "^2.11.2",
     "validate-branch-name": "^1.3.1"
   },
   "lint-staged": {

--- a/site/scripts/verify-broken-links.mjs
+++ b/site/scripts/verify-broken-links.mjs
@@ -12,7 +12,8 @@
 // cassures de bonne foi à corriger dans les fiches.
 //
 // Usage :
-//   node site/scripts/verify-broken-links.mjs <lychee-output.json> [--report=<path.md>]
+//   npm run verify-broken-links -- <lychee-output.json> [--report=<path.md>]
+//   ou : node site/scripts/verify-broken-links.mjs <lychee-output.json> [--report=<path.md>]
 //
 // Sans `--report`, écrit le markdown sur stdout. Exit 0 si le rapport est
 // vide (aucune cassure confirmée), sinon exit 1.
@@ -39,7 +40,10 @@ function parseArgs(argv) {
     else if (!args.input) args.input = a;
   }
   if (!args.input) {
-    console.error('Usage : node verify-broken-links.mjs <lychee.json> [--report=<path.md>]');
+    console.error('Usage : npm run verify-broken-links -- <lychee.json> [--report=<path.md>]');
+    console.error(
+      '   ou : node site/scripts/verify-broken-links.mjs <lychee.json> [--report=<path.md>]',
+    );
     process.exit(2);
   }
   return args;

--- a/site/scripts/verify-broken-links.mjs
+++ b/site/scripts/verify-broken-links.mjs
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+// Stage 2 du pipeline de vérification de liens : lychee détecte les erreurs
+// brutes (HTTP 4xx/5xx, timeouts), ce script les rejoue via Playwright +
+// plugin stealth (vrai Chromium en mode discret) pour distinguer les vraies
+// cassures des protections anti-bot que lychee ne sait pas franchir.
+//
+// Cloudflare, Akamai et autres WAF retournent 403 aux clients HTTP simples
+// alors qu'un navigateur réel passe (cf. issue #71). Le rapport hebdomadaire
+// se retrouvait pollué de domaines exclus à la main, ce qui érodait la
+// valeur de la vérification. Avec ce filtre, on garde dans le rapport final
+// uniquement les URLs où lychee ET Playwright échouent — donc des
+// cassures de bonne foi à corriger dans les fiches.
+//
+// Usage :
+//   node site/scripts/verify-broken-links.mjs <lychee-output.json> [--report=<path.md>]
+//
+// Sans `--report`, écrit le markdown sur stdout. Exit 0 si le rapport est
+// vide (aucune cassure confirmée), sinon exit 1.
+
+import { readFile, writeFile } from 'node:fs/promises';
+import { chromium } from 'playwright-extra';
+import stealth from 'puppeteer-extra-plugin-stealth';
+
+chromium.use(stealth());
+
+// Concurrence à 1 : le plugin stealth attache une session CDP au browser,
+// et fermer un contexte en parallèle pendant qu'un autre worker écrit sur
+// la même session fait planter avec "Target page, context or browser has
+// been closed". Le coût en runtime est limité (~90 URLs × 5-10 s ≈ 10-15 min).
+const CONCURRENCY = 1;
+const TIMEOUT_MS = 30_000;
+const USER_AGENT =
+  'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36';
+
+function parseArgs(argv) {
+  const args = { input: null, report: null };
+  for (const a of argv.slice(2)) {
+    if (a.startsWith('--report=')) args.report = a.slice('--report='.length);
+    else if (!args.input) args.input = a;
+  }
+  if (!args.input) {
+    console.error('Usage : node verify-broken-links.mjs <lychee.json> [--report=<path.md>]');
+    process.exit(2);
+  }
+  return args;
+}
+
+// Extrait les (file, url, status, line) de error_map + timeout_map.
+function collectFailures(lycheeJson) {
+  const out = [];
+  for (const map of [lycheeJson.error_map, lycheeJson.timeout_map]) {
+    if (!map) continue;
+    for (const [file, entries] of Object.entries(map)) {
+      for (const e of entries) {
+        out.push({
+          file,
+          url: e.url,
+          lycheeStatus: e.status?.code ?? 0,
+          lycheeText: e.status?.text ?? 'timeout',
+          line: e.span?.line ?? 0,
+        });
+      }
+    }
+  }
+  return out;
+}
+
+async function verifyOne(browser, url) {
+  const ctx = await browser.newContext({
+    userAgent: USER_AGENT,
+    locale: 'fr-FR',
+    timezoneId: 'Europe/Paris',
+    viewport: { width: 1280, height: 800 },
+  });
+  const page = await ctx.newPage();
+  try {
+    const resp = await page.goto(url, { waitUntil: 'domcontentloaded', timeout: TIMEOUT_MS });
+    const status = resp ? resp.status() : 0;
+    return { url, browserStatus: status, ok: status > 0 && status < 400, error: null };
+  } catch (e) {
+    return { url, browserStatus: 0, ok: false, error: e.message.split('\n')[0].slice(0, 200) };
+  } finally {
+    await ctx.close();
+  }
+}
+
+// Pool simple à N workers concurrents.
+async function verifyAll(browser, failures) {
+  // Dédupliquer par URL (une même URL peut apparaître dans plusieurs fichiers).
+  const byUrl = new Map();
+  for (const f of failures) {
+    if (!byUrl.has(f.url)) byUrl.set(f.url, []);
+    byUrl.get(f.url).push(f);
+  }
+  const uniqueUrls = [...byUrl.keys()];
+  const results = new Map();
+  let next = 0;
+  async function worker() {
+    while (next < uniqueUrls.length) {
+      const i = next++;
+      const url = uniqueUrls[i];
+      const r = await verifyOne(browser, url);
+      results.set(url, r);
+      const tag = r.ok ? '\x1b[32mOK\x1b[0m' : `\x1b[31m${r.browserStatus || 'ERR'}\x1b[0m`;
+      console.error(`  ${tag}  ${url}`);
+    }
+  }
+  await Promise.all(Array.from({ length: CONCURRENCY }, worker));
+  // Re-fusionner avec les fichiers d'origine.
+  return failures.map((f) => ({ ...f, ...results.get(f.url) }));
+}
+
+function buildReport(verified) {
+  const confirmed = verified.filter((r) => !r.ok);
+  // Group par fichier
+  const byFile = new Map();
+  for (const r of confirmed) {
+    if (!byFile.has(r.file)) byFile.set(r.file, []);
+    byFile.get(r.file).push(r);
+  }
+  const lines = [];
+  lines.push('# Liens externes cassés (confirmés par navigateur)');
+  lines.push('');
+  lines.push('Liens détectés en erreur par lychee **et** par un navigateur Chromium');
+  lines.push('avec plugin stealth. Les protections anti-bot sont donc écartées : ces');
+  lines.push('URLs sont des cassures réelles à corriger dans les fiches.');
+  lines.push('');
+  lines.push(`Total : **${confirmed.length}** cassure(s) confirmée(s) sur **${verified.length}**`);
+  lines.push(`signalée(s) initialement par lychee.`);
+  lines.push('');
+  if (confirmed.length === 0) {
+    lines.push('Aucune cassure confirmée. Toutes les erreurs lychee étaient des faux positifs');
+    lines.push('(anti-bot, rate-limit, timeout transient).');
+    return lines.join('\n');
+  }
+  for (const [file, entries] of [...byFile.entries()].sort()) {
+    lines.push(`## ${file}`);
+    lines.push('');
+    for (const e of entries) {
+      const browserNote =
+        e.browserStatus > 0 ? `navigateur ${e.browserStatus}` : e.error || 'navigateur erreur';
+      lines.push(`- ligne ${e.line} : ${e.url} — lychee ${e.lycheeStatus}, ${browserNote}`);
+    }
+    lines.push('');
+  }
+  return lines.join('\n');
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const lycheeJson = JSON.parse(await readFile(args.input, 'utf8'));
+  const failures = collectFailures(lycheeJson);
+  console.error(`Lychee a signalé ${failures.length} erreur(s) à vérifier au navigateur.`);
+  if (failures.length === 0) {
+    const report = buildReport([]);
+    if (args.report) await writeFile(args.report, report);
+    else console.log(report);
+    process.exit(0);
+  }
+  const browser = await chromium.launch({ headless: true });
+  try {
+    console.error(`Vérification (concurrence = ${CONCURRENCY}) :`);
+    const verified = await verifyAll(browser, failures);
+    const confirmed = verified.filter((r) => !r.ok).length;
+    console.error(
+      `Après vérification : ${confirmed} cassure(s) confirmée(s) / ${failures.length} signalée(s).`,
+    );
+    const report = buildReport(verified);
+    if (args.report) {
+      await writeFile(args.report, report);
+      console.error(`Rapport écrit dans ${args.report}.`);
+    } else {
+      console.log(report);
+    }
+    process.exit(confirmed > 0 ? 1 : 0);
+  } finally {
+    await browser.close();
+  }
+}
+
+main().catch((err) => {
+  console.error('Erreur inattendue :', err);
+  process.exit(2);
+});


### PR DESCRIPTION
## Summary

Issue #71 phase 2. Le script Playwright + stealth qui filtre les faux positifs anti-bot de lychee.

**Le problème** : lychee ne distingue pas une vraie 404 d'une 403 Cloudflare/WAF. On accumulait des exclusions ad hoc dans `.lychee.toml`, ce qui érodait la valeur du contrôle.

**La solution** : pipeline en deux étapes.
1. **Lychee** sort en JSON la liste des erreurs.
2. **Ce script** rejoue chaque erreur via Chromium headless + `puppeteer-extra-plugin-stealth`. Seules les URLs où **lychee ET le navigateur** échouent sont conservées dans le rapport final.

**Mesure locale sur le scope actuel** :
- 89 erreurs lychee → **67 cassures confirmées** (22 faux positifs anti-bot écartés)
- Sur 7 domaines anti-bot durs testés isolément, le stealth débloque **5/7** (researchgate, wiley, coe.int, minds-in-bloom résistent — Cloudflare Turnstile niveau pro)

**Scope de cette PR** :
- `site/scripts/verify-broken-links.mjs` : le script, doc en en-tête.
- `package.json` : ajoute `playwright`, `playwright-extra`, `puppeteer-extra-plugin-stealth` en devDeps + script `verify-broken-links`.
- `TESTING.md` : doc d'usage et pré-requis (`npx playwright install chromium`).

**Hors scope (PR suivante)** : intégration dans `links.yml` (lychee → verify → issue). Permet de tester le script localement et de l'éprouver avant de l'attacher au cron.

## Notes techniques

- Concurrence à 1 : le plugin stealth attache une session CDP qui ne supporte pas le multi-context concurrent (crash `Target closed`).
- Le navigateur Chromium se télécharge à part (`npx playwright install chromium`, ~150 Mo, à faire une fois).
- Le script écrit le rapport markdown sur stdout ou `--report=<path>`. Exit 0 si aucune cassure confirmée, 1 sinon.

## Test plan

- [x] Script testé localement sur le scope complet : 89 → 67 (mesure ci-dessus)
- [x] Build et lints au vert
- [ ] CI verte sur la PR

## Plan suivi

PR 2 : intégrer le script dans le workflow `links.yml` (lychee `--format json` → script → issue avec rapport filtré).

Refs #71