### PR TITLE
ci(build): noms explicites pour les jobs lint et build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   lint:
+    name: Lint (Prettier, Markdown, cspell, crosslinks)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -47,6 +48,7 @@ jobs:
         run: npm run lint:crosslinks
 
   build:
+    name: Build Docusaurus + typecheck
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
## Summary

Le panel de checks d'une PR affichait deux chips proches sans aide visuelle pour les distinguer :

- `Build & lint / lint`
- `Build & lint / build`

Ajout d'un `name:` explicite par job :

- `lint` → `Lint (Prettier, Markdown, cspell, crosslinks)`
- `build` → `Build Docusaurus + typecheck`

Aucun changement de comportement, juste de l'affichage.

## Test plan

- [ ] CI verte sur la PR
- [ ] Vérifier visuellement les noms dans le checks panel après push