### PR TITLE
ci(links): pipeline lychee -> Playwright stealth -> issue

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,5 +1,15 @@
 name: Check external links
 
+# Pipeline en deux étapes :
+#  1. Lychee balaye les liens externes des fiches et sort la liste des erreurs
+#     en JSON. Rapide (~3 min), mais ne distingue pas une vraie 404 d'un 403
+#     anti-bot (Cloudflare, WAF) ; ces faux positifs polluaient le rapport.
+#  2. `site/scripts/verify-broken-links.mjs` rejoue chaque erreur via un
+#     Chromium headless + plugin stealth. Seules les URLs où lychee ET le
+#     navigateur échouent sont conservées dans le rapport final.
+#
+# Cf. issue #71 et la PR Playwright (#107) pour le diagnostic.
+
 on:
   schedule:
     - cron: '0 8 * * 1' # tous les lundis à 8h UTC
@@ -11,18 +21,47 @@ permissions:
 
 jobs:
   check-links:
+    name: Vérification liens externes (lychee + Playwright)
     runs-on: ubuntu-latest
+    # Verify peut prendre ~10-15 min sur ~100 URLs en erreur lychee
+    # (concurrency 1 imposée par le plugin stealth). 30 min de marge.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5
 
-      - name: Check external links
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      # Le binaire Chromium pèse ~150 Mo, on le cache pour éviter le re-download
+      # à chaque cron hebdomadaire. La clé inclut le hash du lockfile : si on
+      # bump playwright, le cache est invalidé et Chromium réinstallé.
+      - name: Cache Playwright Chromium
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-chromium-${{ hashFiles('package-lock.json') }}
+
+      - name: Install Playwright Chromium
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install chromium
+
+      # Étape 1 : lychee en sortie JSON (consommable par le script de
+      # vérification). `fail: false` pour que la suite tourne quoi qu'il
+      # arrive ; on regarde l'exit code via les outputs.
+      - name: Check external links (lychee)
         id: check-links
         uses: lycheeverse/lychee-action@v2
         with:
           args: >-
             --config .lychee.toml
-            --verbose
             --no-progress
+            --format json
+            --output ./lychee.json
             'site/docs/**/*.md'
             'site/docs/**/*.mdx'
             'README.md'
@@ -30,19 +69,46 @@ jobs:
             'TESTING.md'
           fail: false
 
-      # Cherche s'il existe déjà une issue ouverte avec ce titre.
-      # Si oui, on passe son numéro à l'étape suivante pour mettre
-      # à jour son contenu plutôt que d'en créer une nouvelle (sinon
-      # on accumule 52 issues identiques par an, cf. #91).
+      # Étape 2 : filtre Playwright. Si lychee n'a rien remonté, on n'a rien
+      # à filtrer ; sinon on rejoue chaque erreur dans Chromium stealth et
+      # on construit le rapport markdown final.
       #
-      # Tri explicite par `updatedAt` décroissant pour départager
-      # plusieurs issues homonymes (cas réel après #92 : #61 et #71
-      # existent toutes les deux). On met à jour la plus récemment
-      # touchée, ce qui converge sur une seule issue active dans le
-      # temps.
+      # `|| true` après le script : il sort en 1 si des cassures sont
+      # confirmées, mais on veut continuer le step pour examiner le rapport.
+      # On détermine ensuite via grep si le rapport contient au moins une
+      # section fichier (`## site/docs/...`).
+      - name: Verify with browser (filter anti-bot false positives)
+        id: verify
+        if: steps.check-links.outputs.exit_code != '0'
+        run: |
+          if [ ! -f ./lychee.json ]; then
+            echo "::error::lychee.json absent — lychee a probablement planté avant d'écrire son rapport."
+            exit 1
+          fi
+          node site/scripts/verify-broken-links.mjs ./lychee.json --report=./final-report.md || true
+          if [ ! -s ./final-report.md ]; then
+            echo "::error::Le script n'a produit aucun rapport."
+            exit 1
+          fi
+          if grep -q '^## ' ./final-report.md; then
+            echo "has_breakages=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_breakages=false" >> "$GITHUB_OUTPUT"
+            echo "Aucune cassure confirmée par le navigateur — toutes les erreurs lychee étaient des faux positifs anti-bot."
+          fi
+
+      # Cherche s'il existe déjà une issue ouverte avec ce titre. Si oui, on
+      # passe son numéro à l'étape suivante pour mettre à jour son contenu
+      # plutôt que d'en créer une nouvelle (sinon on accumule 52 issues
+      # identiques par an, cf. #91).
+      #
+      # Tri explicite par `updatedAt` décroissant pour départager plusieurs
+      # issues homonymes (cas réel après #92 : #61 et #71 existaient toutes
+      # les deux). On met à jour la plus récemment touchée, ce qui converge
+      # sur une seule issue active dans le temps.
       - name: Find existing open issue
         id: find-issue
-        if: steps.check-links.outputs.exit_code != '0'
+        if: steps.verify.outputs.has_breakages == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -54,11 +120,11 @@ jobs:
             --jq 'sort_by(.updatedAt) | reverse | .[0].number // empty')
           echo "issue_number=${issue_number}" >> "$GITHUB_OUTPUT"
 
-      - name: Update or create issue on failure
-        if: steps.check-links.outputs.exit_code != '0'
+      - name: Update or create issue
+        if: steps.verify.outputs.has_breakages == 'true'
         uses: peter-evans/create-issue-from-file@v6
         with:
           title: 'Liens externes cassés détectés'
-          content-filepath: ./lychee/out.md
+          content-filepath: ./final-report.md
           issue-number: ${{ steps.find-issue.outputs.issue_number }}
           labels: 'bug,liens'

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -29,30 +29,11 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v5
-        with:
-          node-version: 20
-          cache: npm
-
-      - run: npm ci
-
-      # Le binaire Chromium pèse ~150 Mo, on le cache pour éviter le re-download
-      # à chaque cron hebdomadaire. La clé inclut le hash du lockfile : si on
-      # bump playwright, le cache est invalidé et Chromium réinstallé.
-      - name: Cache Playwright Chromium
-        id: playwright-cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-chromium-${{ hashFiles('package-lock.json') }}
-
-      - name: Install Playwright Chromium
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: npx playwright install chromium
-
-      # Étape 1 : lychee en sortie JSON (consommable par le script de
-      # vérification). `fail: false` pour que la suite tourne quoi qu'il
-      # arrive ; on regarde l'exit code via les outputs.
+      # Étape 1 : lychee en premier. Sortie JSON consommable par le script
+      # de vérification. `fail: false` pour que la suite tourne quoi qu'il
+      # arrive ; on regarde l'exit code via les outputs. On ne fait pas
+      # `npm ci` ni Playwright install ici : si lychee ne remonte rien
+      # (cas courant), inutile de payer ces étapes.
       - name: Check external links (lychee)
         id: check-links
         uses: lycheeverse/lychee-action@v2
@@ -69,14 +50,40 @@ jobs:
             'TESTING.md'
           fail: false
 
-      # Étape 2 : filtre Playwright. Si lychee n'a rien remonté, on n'a rien
-      # à filtrer ; sinon on rejoue chaque erreur dans Chromium stealth et
-      # on construit le rapport markdown final.
-      #
-      # `|| true` après le script : il sort en 1 si des cassures sont
-      # confirmées, mais on veut continuer le step pour examiner le rapport.
-      # On détermine ensuite via grep si le rapport contient au moins une
-      # section fichier (`## site/docs/...`).
+      # Étapes suivantes : seulement si lychee a remonté des erreurs. Évite
+      # d'installer Node + Chromium pour rien quand la semaine est propre.
+      - name: Setup Node
+        if: steps.check-links.outputs.exit_code != '0'
+        uses: actions/setup-node@v5
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install npm dependencies
+        if: steps.check-links.outputs.exit_code != '0'
+        run: npm ci
+
+      # Le binaire Chromium pèse ~150 Mo, on le cache pour éviter le re-download
+      # à chaque cron hebdomadaire. La clé inclut le hash du lockfile : si on
+      # bump playwright, le cache est invalidé et Chromium réinstallé.
+      - name: Cache Playwright Chromium
+        id: playwright-cache
+        if: steps.check-links.outputs.exit_code != '0'
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-chromium-${{ hashFiles('package-lock.json') }}
+
+      - name: Install Playwright Chromium
+        if: steps.check-links.outputs.exit_code != '0' && steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install chromium
+
+      # Étape 2 : filtre Playwright. On lit l'exit code du script plutôt que
+      # de parser le rapport :
+      #  - 0 = aucune cassure confirmée (toutes les erreurs lychee étaient
+      #        des faux positifs anti-bot, on ne touche pas à l'issue).
+      #  - 1 = cassures confirmées (lychee ET le navigateur en échec).
+      #  - 2+ = erreur inattendue (le script a planté), on fait remonter.
       - name: Verify with browser (filter anti-bot false positives)
         id: verify
         if: steps.check-links.outputs.exit_code != '0'
@@ -85,17 +92,23 @@ jobs:
             echo "::error::lychee.json absent — lychee a probablement planté avant d'écrire son rapport."
             exit 1
           fi
-          node site/scripts/verify-broken-links.mjs ./lychee.json --report=./final-report.md || true
-          if [ ! -s ./final-report.md ]; then
-            echo "::error::Le script n'a produit aucun rapport."
-            exit 1
-          fi
-          if grep -q '^## ' ./final-report.md; then
-            echo "has_breakages=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_breakages=false" >> "$GITHUB_OUTPUT"
-            echo "Aucune cassure confirmée par le navigateur — toutes les erreurs lychee étaient des faux positifs anti-bot."
-          fi
+          set +e
+          node site/scripts/verify-broken-links.mjs ./lychee.json --report=./final-report.md
+          rc=$?
+          set -e
+          case "$rc" in
+            0)
+              echo "has_breakages=false" >> "$GITHUB_OUTPUT"
+              echo "Aucune cassure confirmée — toutes les erreurs lychee étaient des faux positifs anti-bot."
+              ;;
+            1)
+              echo "has_breakages=true" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "::error::Le script verify-broken-links a planté (exit $rc)."
+              exit "$rc"
+              ;;
+          esac
 
       # Cherche s'il existe déjà une issue ouverte avec ce titre. Si oui, on
       # passe son numéro à l'étape suivante pour mettre à jour son contenu


### PR DESCRIPTION
## Summary

Finalise #71. Branche le script Playwright stealth (PR #107) dans le workflow hebdomadaire `links.yml`. Le pipeline devient :

```
lychee --format json    →    verify-broken-links.mjs    →    issue
(détecte erreurs brutes)     (rejoue via Chromium stealth,    (filtré : seules les
                              écarte les anti-bot)              cassures confirmées)
```

**Effet attendu** : l'issue #71 ne contiendra plus que les URLs où lychee **et** le navigateur ont échoué. Plus de bruit hebdomadaire dû aux 403 Cloudflare. La phrase d'accroche du rapport sera "X cassure(s) confirmée(s) sur Y signalée(s) initialement par lychee".

## Détails techniques

- **Cache Chromium** : `actions/cache@v4` sur `~/.cache/ms-playwright`, clé sur le hash du lockfile. Premier run : ~2 min de download. Runs suivants : ~10 s.
- **Timeout 30 min** : le `verify` peut prendre ~10-15 min sur 100 URLs (concurrence 1 imposée par le plugin stealth qui crash en multi-context, cf. #107).
- **`if: steps.verify.outputs.has_breakages == 'true'`** : si toutes les erreurs lychee étaient des faux positifs anti-bot, on ne crée/met pas à jour l'issue. Plus de bruit cron quand le navigateur valide tout.
- **Garde-fous** : exit franc si `lychee.json` est absent (lychee a planté avant écriture) ou si le script ne produit pas de rapport.

## Test plan

- [ ] CI verte sur la PR (le workflow lui-même ne s'exécute pas en PR, déclencheur `schedule` + `workflow_dispatch` uniquement — la PR teste juste la syntaxe via les autres workflows)
- [ ] **Trigger manuel post-merge** : `gh workflow run links.yml`
- [ ] Vérifier sur le run :
  - Cache Chromium : hit ou install propre
  - Sortie lychee en JSON : `lychee.json` créé
  - Verify script : log montre "X cassure(s) confirmée(s) / Y signalée(s)"
  - Issue #71 mise à jour avec le rapport filtré (pas de duplication)
- [ ] Vérifier que les domaines anti-bot durs (researchgate, wiley, etc.) restent dans le rapport (Cloudflare Turnstile résiste même au stealth), mais que ademe.fr, unicef.org, britannica.com, etc. disparaissent

Closes #71