### PR TITLE
fix(ci): passe format/output à l'action lychee, pas dans args

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -38,11 +38,17 @@ jobs:
         id: check-links
         uses: lycheeverse/lychee-action@v2
         with:
+          # `format` et `output` doivent passer par les inputs de l'action,
+          # pas dans `args` : sinon l'action plante avec "set in args as well
+          # as in the action configuration". `jobSummary: false` parce que le
+          # résumé GitHub est généré à partir du markdown ; ici on produit
+          # du JSON brut, le résumé serait vide.
+          format: json
+          output: ./lychee.json
+          jobSummary: false
           args: >-
             --config .lychee.toml
             --no-progress
-            --format json
-            --output ./lychee.json
             'site/docs/**/*.md'
             'site/docs/**/*.mdx'
             'README.md'


### PR DESCRIPTION
## Summary

Premier trigger de #109 post-merge a planté :

\`\`\`
Error: 'output' is set in args as well as in the action configuration.
Please remove one of them.
\`\`\`

L'action \`lycheeverse/lychee-action@v2\` a ses propres inputs \`format\` (défaut \`markdown\`) et \`output\` (défaut \`lychee/out.md\`). En passant \`--format json --output ./lychee.json\` directement dans \`args\`, on duplique avec ses paramètres internes et elle refuse.

Fix :
- \`format: json\` et \`output: ./lychee.json\` remontés en inputs de l'action.
- \`jobSummary: false\` parce que le résumé GitHub est généré à partir du markdown ; ici on produit du JSON brut, le résumé serait vide ou cassé.

## Test plan

- [ ] CI verte sur la PR
- [ ] Trigger manuel post-merge : \`gh workflow run links.yml\`
- [ ] Vérifier que lychee tourne, \`lychee.json\` créé, et que le step \`verify\` enchaîne

Refs #71