### PR TITLE
fix(ci): pin lychee v0.24.2 + bump cache@v5 + ligne ? défensif

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -43,6 +43,13 @@ jobs:
           # as in the action configuration". `jobSummary: false` parce que le
           # résumé GitHub est généré à partir du markdown ; ici on produit
           # du JSON brut, le résumé serait vide.
+          #
+          # `lycheeVersion: v0.24.2` épingle la version pour matcher celle
+          # utilisée en local (cargo install). L'action par défaut prend
+          # v0.23.0 dont la sortie JSON est moins complète (pas de
+          # `span.line` pour les erreurs), ce qui faisait apparaître
+          # `ligne 0` partout dans le rapport.
+          lycheeVersion: v0.24.2
           format: json
           output: ./lychee.json
           jobSummary: false
@@ -75,7 +82,7 @@ jobs:
       - name: Cache Playwright Chromium
         id: playwright-cache
         if: steps.check-links.outputs.exit_code != '0'
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-chromium-${{ hashFiles('package-lock.json') }}

--- a/site/scripts/verify-broken-links.mjs
+++ b/site/scripts/verify-broken-links.mjs
@@ -61,7 +61,10 @@ function collectFailures(lycheeJson) {
           url: e.url,
           lycheeStatus: e.status?.code ?? 0,
           lycheeText: e.status?.text ?? 'timeout',
-          line: e.span?.line ?? 0,
+          // `span.line` est rempli par lychee ≥ 0.24 ; certaines anciennes
+          // versions le laissent absent. On garde `null` pour signaler
+          // l'absence côté rendu (« ligne ? »).
+          line: e.span?.line ?? null,
         });
       }
     }
@@ -143,7 +146,8 @@ function buildReport(verified) {
     for (const e of entries) {
       const browserNote =
         e.browserStatus > 0 ? `navigateur ${e.browserStatus}` : e.error || 'navigateur erreur';
-      lines.push(`- ligne ${e.line} : ${e.url} — lychee ${e.lycheeStatus}, ${browserNote}`);
+      const linePrefix = e.line ? `ligne ${e.line}` : 'ligne ?';
+      lines.push(`- ${linePrefix} : ${e.url} — lychee ${e.lycheeStatus}, ${browserNote}`);
     }
     lines.push('');
   }


### PR DESCRIPTION
## Summary

Premier run du pipeline (#109/#110) a tourné de bout en bout mais avec deux soucis cosmétiques.

**1. `ligne 0` partout dans le rapport**
Cause : `lycheeverse/lychee-action@v2` télécharge lychee `v0.23.0` par défaut, dont la sortie JSON ne remplit pas `span.line` pour les erreurs. Localement avec `cargo install lychee` (v0.24.2), le champ est bien rempli.

Fix :
- Pin `lycheeVersion: v0.24.2` dans l'action pour matcher la version locale.
- Fallback défensif côté script : si `span.line` reste absent (ancienne version, format inattendu), afficher `ligne ?` plutôt que `ligne 0`.

**2. Warning Node 20 sur `actions/cache@v4`**
Bump à `actions/cache@v5` pour rester aligné avec `actions/checkout@v5` et `actions/setup-node@v5` (cf. #98).

## Test plan

- [x] Test local du script sur le JSON local avec la nouvelle logique : `ligne 243`, `ligne 235`, etc. affichés correctement.
- [ ] CI verte sur la PR.
- [ ] Trigger manuel post-merge `gh workflow run links.yml` pour valider que la v0.24.2 sort bien `span.line` en CI.

Refs #71