### PR TITLE
fix(ci): revert pin lychee v0.24.2 (incompatible avec lychee-action@v2)

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -44,12 +44,15 @@ jobs:
           # résumé GitHub est généré à partir du markdown ; ici on produit
           # du JSON brut, le résumé serait vide.
           #
-          # `lycheeVersion: v0.24.2` épingle la version pour matcher celle
-          # utilisée en local (cargo install). L'action par défaut prend
-          # v0.23.0 dont la sortie JSON est moins complète (pas de
-          # `span.line` pour les erreurs), ce qui faisait apparaître
-          # `ligne 0` partout dans le rapport.
-          lycheeVersion: v0.24.2
+          # Pas de `lycheeVersion` épinglée : l'action `@v2` ne sait pas
+          # extraire correctement l'archive lychee v0.24.x (binaire dans un
+          # sous-dossier au lieu de la racine du temp dir, cf. `install:
+          # cannot stat .../lychee-download/lychee`). On reste donc sur la
+          # version par défaut de l'action (v0.23.0 à ce jour), dont la
+          # sortie JSON n'inclut pas `span.line` pour les erreurs. Le script
+          # `verify-broken-links.mjs` gère ce cas en affichant `ligne ?` à
+          # la place du numéro de ligne. À ré-épingler quand l'action sera
+          # mise à jour pour gérer la nouvelle layout des releases.
           format: json
           output: ./lychee.json
           jobSummary: false


### PR DESCRIPTION
## Summary

Le pin \`lycheeVersion: v0.24.2\` introduit en #112 plante le workflow. L'action \`lycheeverse/lychee-action@v2\` ne sait pas extraire l'archive de lychee v0.24.x (le binaire est dans un sous-dossier \`lychee-x86_64-unknown-linux-gnu/\` alors que l'action s'attend à le trouver à la racine du temp dir) :

\`\`\`
install: cannot stat '/home/runner/work/_temp/lychee-download/lychee':
No such file or directory
\`\`\`

Fix : revert du pin. On reste sur la version par défaut de l'action (v0.23.0 à ce jour). La sortie JSON n'a pas \`span.line\` pour les erreurs, mais le script \`verify-broken-links.mjs\` (#112) gère ce cas en affichant \`ligne ?\` plutôt que \`ligne 0\`. Pas idéal mais lisible.

Le fallback \`ligne ?\` et le bump \`actions/cache@v5\` de #112 sont conservés. À ré-épingler quand \`lychee-action\` sera mis à jour pour la nouvelle layout des releases v0.24+.

## Test plan

- [ ] CI verte sur la PR
- [ ] Trigger manuel post-merge : \`gh workflow run links.yml\`
- [ ] Vérifier que lychee tourne (v0.23.0 par défaut) et que le rapport affiche \`ligne ?\` partout, sans plus de crash

Refs #71