### PR TITLE
fix(thedexterlab): explainthatstuff escapement 404 -> pendulum-clocks

### DIFF
--- a/site/docs/thedexterlab/mesurer-temps-pendule.md
+++ b/site/docs/thedexterlab/mesurer-temps-pendule.md
@@ -283,7 +283,7 @@ Cette expérimentation avec un pendule et un mécanisme d'échappement a permis 
 Pour aller plus loin :
 
 - [Pendules et Horloges](https://www.khanacademy.org/science/physics/mechanical-waves-and-sound/simple-harmonic-motion/a/simple-harmonic-motion-review) - Un cours de Khan Academy sur les oscillations.
-- [Explication des mécanismes d'échappement](https://www.explainthatstuff.com/how-escapements-work.html) - Un article expliquant le fonctionnement des mécanismes d'échappement.
+- [Explication des mécanismes d'échappement](https://www.explainthatstuff.com/how-pendulum-clocks-work.html) - Un article expliquant le fonctionnement des mécanismes d'échappement.
 
 ---
 


### PR DESCRIPTION
Le lien sur `how-escapements-work.html` retourne 404 (pas de snapshot archive.org). Le site existe encore et publie un article plus large [How pendulum clocks work](https://www.explainthatstuff.com/how-pendulum-clocks-work.html) qui traite explicitement des mécanismes d'échappement (5+ occurrences du terme 'escapement'). Bascule sur cette URL.

Refs #71