### PR TITLE
fix(magnetics): magnetics.edu-up.fr 404 -> archive.org

### DIFF
--- a/site/docs/magnetics/makecode-stm32.md
+++ b/site/docs/magnetics/makecode-stm32.md
@@ -49,7 +49,7 @@ Cette fiche d'activité propose de créer des projets plus complexes en utilisan
 
 **Ressources :**
 
-- [magnetics.edu-up.fr](https://www.magnetics.edu-up.fr/)
+- [magnetics.edu-up.fr (archive.org, 2025-12-06)](https://web.archive.org/web/20251206204723/https://magnetics.edu-up.fr/)
 - [blog.rtone.fr/bluetooth-mesh](https://blog.rtone.fr/bluetooth-mesh)
 - [Bluetooth basse consommation (Wikipédia)](https://fr.wikipedia.org/wiki/Bluetooth_%C3%A0_basse_consommation)
 

--- a/site/docs/magnetics/microbit.md
+++ b/site/docs/magnetics/microbit.md
@@ -47,7 +47,7 @@ Cette fiche d'activité propose de créer des projets plus complexes en utilisan
 
 **Ressources :**
 
-- [magnetics.edu-up.fr](https://www.magnetics.edu-up.fr/)
+- [magnetics.edu-up.fr (archive.org, 2025-12-06)](https://web.archive.org/web/20251206204723/https://magnetics.edu-up.fr/)
 - [blog.rtone.fr/bluetooth-mesh](https://blog.rtone.fr/bluetooth-mesh)
 - [Bluetooth basse consommation (Wikipédia)](https://fr.wikipedia.org/wiki/Bluetooth_%C3%A0_basse_consommation)
 

--- a/site/docs/magnetics/micropython.md
+++ b/site/docs/magnetics/micropython.md
@@ -49,7 +49,7 @@ Cette fiche d'activité propose de créer des projets plus complexes en utilisan
 
 **Ressources :**
 
-- [magnetics.edu-up.fr](https://www.magnetics.edu-up.fr/)
+- [magnetics.edu-up.fr (archive.org, 2025-12-06)](https://web.archive.org/web/20251206204723/https://magnetics.edu-up.fr/)
 - [blog.rtone.fr/bluetooth-mesh](https://blog.rtone.fr/bluetooth-mesh)
 - [Bluetooth basse consommation (Wikipédia)](https://fr.wikipedia.org/wiki/Bluetooth_%C3%A0_basse_consommation)
 


### PR DESCRIPTION
Le site du projet Edu-up Magnetics renvoie 404 depuis sa fermeture. Snapshot [archive.org du 2025-12-06](https://web.archive.org/web/20251206204723/https://magnetics.edu-up.fr/) disponible avec le contenu original (page d'accueil du projet).

Bascule sur l'archive pour les 3 fiches qui pointaient vers l'URL (micropython, microbit, makecode-stm32). Label enrichi avec « (archive.org, 2025-12-06) » pour signaler explicitement au lecteur que c'est une archive.

Refs #71