### PR TITLE
fix(lets-steam): sciencebuddies + makeuseof -> archive.org

### DIFF
--- a/site/docs/lets-steam/r1as02-breadboard.md
+++ b/site/docs/lets-steam/r1as02-breadboard.md
@@ -174,7 +174,7 @@ Ce programme est une version étendue du programme "Faire clignoter une LED" ada
 ## Aller plus loin
 
 - **Comment utiliser une breadboard** - Tutoriel vidéo présentant une introduction aux breadboards et expliquant comment les utiliser dans des projets électroniques pour débutants.
-  https://www.sciencebuddies.org/science-fair-projects/references/how-to-use-a-breadboard
+  https://web.archive.org/web/20260209225821/https://www.sciencebuddies.org/science-fair-projects/references/how-to-use-a-breadboard
 
 - **Utilisez une vraie breadboard (planche à pain) pour prototyper votre circuit** - Prototypage pas à pas avec une breadboard.
   https://www.instructables.com/Use-a-real-Bread-Board-for-prototyping-your-circui/

--- a/site/docs/lets-steam/r1as03-boutons.md
+++ b/site/docs/lets-steam/r1as03-boutons.md
@@ -183,8 +183,8 @@ La ligne la plus importante ici est la condition `if (weCanPushIt) { ... }` qui 
   https://microbit.org/projects/make-it-code-it/reaction-game/
 
 - **Découvrez ce qu'est une variable** - Apprenez-en plus sur les variables et les fonctions en programmation.
-  https://www.computerhope.com/jargon/v/variable.htm,
-  https://web.archive.org/web/20230620020907/https://www.makeuseof.com/what-is-a-function-programming/
+  - https://www.computerhope.com/jargon/v/variable.htm
+  - https://web.archive.org/web/20230620020907/https://www.makeuseof.com/what-is-a-function-programming/
 
 ---
 

--- a/site/docs/lets-steam/r1as03-boutons.md
+++ b/site/docs/lets-steam/r1as03-boutons.md
@@ -184,7 +184,7 @@ La ligne la plus importante ici est la condition `if (weCanPushIt) { ... }` qui 
 
 - **Découvrez ce qu'est une variable** - Apprenez-en plus sur les variables et les fonctions en programmation.
   https://www.computerhope.com/jargon/v/variable.htm,
-  https://www.makeuseof.com/what-is-a-function-programming/
+  https://web.archive.org/web/20230620020907/https://www.makeuseof.com/what-is-a-function-programming/
 
 ---
 


### PR DESCRIPTION
Deux ressources de référence cassées détectées par #71 :

- [r1as02-breadboard.md](site/docs/lets-steam/r1as02-breadboard.md) : `sciencebuddies.org/.../how-to-use-a-breadboard` retourne 403 même avec Playwright stealth (Cloudflare hardcore). [Snapshot archive.org du 2026-02-09](https://web.archive.org/web/20260209225821/https://www.sciencebuddies.org/science-fair-projects/references/how-to-use-a-breadboard) disponible.
- [r1as03-boutons.md](site/docs/lets-steam/r1as03-boutons.md) : `makeuseof.com/what-is-a-function-programming/` 404, article supprimé. [Snapshot archive.org du 2023-06-20](https://web.archive.org/web/20230620020907/https://www.makeuseof.com/what-is-a-function-programming/) conservé.

Refs #71