### PR TITLE
fix(jeditrack): 6 liens cassés (404/403/500/migration HTTPS)

### DIFF
--- a/site/docs/jeditrack/borne-arcade.md
+++ b/site/docs/jeditrack/borne-arcade.md
@@ -232,7 +232,7 @@ Dans le projet "Borne d'arcade", nous avions le choix entre opter pour un kit pr
 Nous avons principalement utilisé du **MDF (Medium Density Fiberboard) de 18 mm d'épaisseur**. Le MDF se coupe, se perce et se ponce aisément, c'est un matériau économique. Nous l'avons fait découper à la demande chez Leroy Merlin (≈ 200 EUR de bois). Sa surface est idéale pour la peinture et les stickers ; il résiste bien aux changements de température et d'humidité, et se trouve facilement dans les magasins de bricolage.
 
 :::note[Ressources]
-- [Panneaux MDF chez Leroy Merlin](https://www.leroymerlin.fr/produits/menuiserie/panneau-planche-et-materiaux-bois/panneau-bois-agglomere-mdf/panneau-mdf/)
+- [Leroy Merlin](https://www.leroymerlin.fr/) — rayon menuiserie, panneaux bois agglomérés MDF (chercher « panneau MDF » sur le site)
 :::
 
 ### Finition et esthétique
@@ -240,11 +240,11 @@ Nous avons principalement utilisé du **MDF (Medium Density Fiberboard) de 18 mm
 Approche simple mais collaborative : les jeunes ont réalisé des essais de peinture sur les prototypes avec plusieurs associations de couleurs, puis ont validé collectivement le choix final (en prenant en compte les chocs et traces potentiels). Ils ont proposé des dessins sur une zone limitée et dédiée, le reste étant recouvert de stickers sélectionnés ensemble. Bandes de chant pour protéger les tranches.
 
 :::note[Ressources stickers et finitions]
-- https://www.buzz-arcade.com/fr/36-stickers-bornes
+- https://web.archive.org/web/20251013023643/https://www.buzz-arcade.com/fr/36-stickers-bornes
 - https://www.jdfarcade.com/stickers-borne-d-arcade/376-sticker-supreme.html
 - https://stickergameshop.com/
 - https://www.spreadshirt.fr/shop/papeterie/stickers/pop+culture/
-- https://www.goodstickers.fr/stickers/jeux-video/
+- https://web.archive.org/web/20240624200758/https://www.goodstickers.fr/stickers/jeux-video/
 - https://adhesifs-de-france.fr/80-pop-culture
 - T-molding : https://fabulous-arcade.com/fr/58-t-molding
 :::

--- a/site/docs/jeditrack/etude-confort-thermique.md
+++ b/site/docs/jeditrack/etude-confort-thermique.md
@@ -409,7 +409,7 @@ Pour les structures à la recherche d'options à la fois abordables et accessibl
 
 - [**ADEME - Maîtrise de l'énergie dans le bâtiment**](https://www.ademe.fr/expertises/batiment) - Données officielles sur la consommation énergétique des logements français
 - [**ADEME - Guide de l'isolation**](https://www.ademe.fr/particuliers-eco-citoyens/habitation/bien-choisir-equipements/isolation) - Comprendre les enjeux de l'isolation thermique
-- [**Observatoire National de la Précarité Énergétique**](https://onpe.org/) - Statistiques et analyses sur les inégalités de confort thermique
+- [**Observatoire National de la Précarité Énergétique**](https://web.archive.org/web/20251231065014/https://onpe.org/) (archive.org, 2025-12-31) - Statistiques et analyses sur les inégalités de confort thermique
 - [**Micro:bit Educational Foundation**](https://microbit.org/fr/) - Ressources pédagogiques pour l'utilisation de micro:bit dans des projets environnementaux
 - [**Point Info Énergie**](https://www.faire.gouv.fr/trouver-un-conseiller) - Réseau de conseillers pour accompagner les projets d'efficacité énergétique
 - [**Thermographie.fr**](https://www.thermographie.fr/) - Ressources techniques sur l'imagerie thermique dans le bâtiment

--- a/site/docs/jeditrack/partager-donnees-open-source.md
+++ b/site/docs/jeditrack/partager-donnees-open-source.md
@@ -263,7 +263,7 @@ Le respect du Règlement Général sur la Protection des Données impose de veil
 - https://framaforms.org/ (questionnaires et sondages)
 - https://postimg.cc/ (hébergement d'images)
 - https://www.opendatafrance.net/ (réseau des collectivités)
-- https://www.cnil.fr/fr/educnum (protection des données)
+- https://www.cnil.fr/ (protection des données — ressources éducatives en ligne)
 - https://creativecommons.fr/ (licences ouvertes)
 - https://fing.org/ (innovation numérique participative)
 

--- a/site/docs/jeditrack/realiser-pochoirs-decoupe.md
+++ b/site/docs/jeditrack/realiser-pochoirs-decoupe.md
@@ -128,7 +128,7 @@ Les fablabs incarnent l'esprit maker : partage, collaboration, innovation ouvert
 
 **Comment trouver un fablab près de chez vous ?**
 
-Pour localiser un fablab dans votre région, plusieurs ressources fiables s'offrent à vous. Le **Réseau Français des FabLabs** ([www.fablab.fr](http://www.fablab.fr/)) propose une carte interactive très complète des fablabs français, avec des fiches détaillées indiquant les équipements disponibles, les horaires d'ouverture et les tarifs pratiqués. Au niveau international, la **Fab Foundation** ([www.fablabs.io](http://www.fablabs.io/)) maintient une cartographie mondiale des fablabs officiels respectant les critères de labellisation du MIT.
+Pour localiser un fablab dans votre région, plusieurs ressources fiables s'offrent à vous. Le **Réseau Français des FabLabs** ([www.fablab.fr](http://www.fablab.fr/)) propose une carte interactive très complète des fablabs français, avec des fiches détaillées indiquant les équipements disponibles, les horaires d'ouverture et les tarifs pratiqués. Au niveau international, la **Fab Foundation** ([www.fablabs.io](https://www.fablabs.io/)) maintient une cartographie mondiale des fablabs officiels respectant les critères de labellisation du MIT.
 
 D'autres plateformes élargissent le spectre de recherche. **Makery** ([www.makery.info](http://www.makery.info/)) offre une cartographie européenne qui inclut non seulement les fablabs mais aussi les hackerspaces et repair cafés, souvent équipés d'outils similaires. Le site **France Tiers-Lieux** (francetierslieux.fr) répertorie l'ensemble des tiers-lieux français par région et spécialités, permettant d'identifier les espaces dédiés à la fabrication numérique.
 


### PR DESCRIPTION
Triage des cassures #71 sur jeditrack. 4 fiches touchées, 6 liens corrigés, 1 faux positif documenté.

| Fiche | Lien | Action |
|---|---|---|
| `borne-arcade.md` | leroymerlin.fr/.../panneau-mdf/ (403 hardcore, NO_ARCHIVE) | → racine leroymerlin.fr + indication du rayon |
| `borne-arcade.md` | buzz-arcade.com/.../stickers-bornes (404) | → archive.org 2025-10 |
| `borne-arcade.md` | goodstickers.fr (404) | → archive.org 2024-06 |
| `etude-confort-thermique.md` | onpe.org/ (403 hardcore) | → archive.org 2025-12 |
| `partager-donnees-open-source.md` | cnil.fr/fr/educnum (500 persistant) | → racine cnil.fr |
| `realiser-pochoirs-decoupe.md` | http://www.fablabs.io/ (404) | → https:// (migration HTTPS, le contenu est intact) |

**Pas touché** : `cartographie-sensible.md` (geoconfluences.ens-lyon.fr/glossaire/carte-sensible). Marqué cassé par le pipeline (timeout 30 s côté Playwright stealth), mais `curl` répond 200 en 165 ms. Faux positif lié au JS lourd de la page, le lien fonctionne en réalité. À surveiller au prochain cron.

Refs #71