### PR TITLE
fix(projets-du-lab): 11 liens cassés (5 fiches)

### DIFF
--- a/site/docs/projets-du-lab/audio-hifi.md
+++ b/site/docs/projets-du-lab/audio-hifi.md
@@ -25,11 +25,11 @@ Le point de départ est la convergence de trois découvertes :
 
 - Les enceintes **LXmini**, conçues par Siegfried Linkwitz (inventeur des filtres Linkwitz-Riley). Elles promettent une restitution exceptionnelle de la scène sonore et sont réalisables soi-même. Le [site de Linkwitz](http://www.linkwitzlab.com/LXmini/Introduction.htm) est une mine de connaissances sur les principes acoustiques. Le dossier de réalisation est payant mais en vaut le prix.
 
-- La possibilité de remplacer les filtres passifs des enceintes par du **traitement numérique du signal** (filtrage, égalisation, retards). Plus besoin de composants ésotériques ni de discussions sans fin sur les condensateurs. Le tout peut tourner sur une Raspberry Pi avec des outils open source ([HOWTO](http://rtaylor.sites.tru.ca/2013/06/25/digital-crossovereq-with-open-source-software-howto/)).
+- La possibilité de remplacer les filtres passifs des enceintes par du **traitement numérique du signal** (filtrage, égalisation, retards). Plus besoin de composants ésotériques ni de discussions sans fin sur les condensateurs. Le tout peut tourner sur une Raspberry Pi avec des outils open source ([HOWTO, archive.org 2024-02](https://web.archive.org/web/20240227142132/http://rtaylor.sites.tru.ca/2013/06/25/digital-crossovereq-with-open-source-software-howto/)).
 
-- Les amplificateurs **classe D Full Digital** (FDA), qui atteignent des niveaux de performance remarquables pour un coût modeste ([Derrière le micro exactement](http://audiolalies.blogspot.fr/2015/03/derriere-le-micro-exactement.html#!/2015/03/derriere-le-micro-exactement.html), [FX Audio D802](http://www.audiophile-magazine.com/autour-des-1000-et-moins/fx-audio-d802/)).
+- Les amplificateurs **classe D Full Digital** (FDA), qui atteignent des niveaux de performance remarquables pour un coût modeste ([Derrière le micro exactement, archive.org 2018-05](https://web.archive.org/web/20180521062932/http://audiolalies.blogspot.fr/2015/03/derriere-le-micro-exactement.html), [FX Audio D802](http://www.audiophile-magazine.com/autour-des-1000-et-moins/fx-audio-d802/)).
 
-Le fil rouge du projet : [David 3, Goliath 0](http://audiolalies.blogspot.fr/2016/03/tribune-libre.html#!/2016/03/tribune-libre.html).
+Le fil rouge du projet : [David 3, Goliath 0, archive.org 2018-05](https://web.archive.org/web/20180528185301/http://audiolalies.blogspot.fr/2016/03/tribune-libre.html).
 
 ### Architecture du système
 

--- a/site/docs/projets-du-lab/decouverte-bus-can.md
+++ b/site/docs/projets-du-lab/decouverte-bus-can.md
@@ -27,7 +27,7 @@ Matériel nécessaire :
 
 - 2 Arduino Uno
 
-- 2 [shield CAN-BUS Sparkfun](https://www.sparkfun.com/products/10039) ou un [shield Seeduino](https://www.seeedstudio.com/CAN-BUS-Shield-V1.2-p-2256.html) ou un [breakout](https://www.botshop.co.za/product/can-bus-module-arduino-mcp2515/)
+- 2 [shield CAN-BUS Sparkfun](https://www.sparkfun.com/products/10039) ou un [shield Seeduino](https://www.seeedstudio.com/CAN-BUS-Shield-V1.2-p-2256.html) ou un [breakout (archive.org 2021-04)](https://web.archive.org/web/20210422223931/https://www.botshop.co.za/product/can-bus-module-arduino-mcp2515/)
 
 - 2 Résistances de 120 Ohms (terminaison de bus, une à chaque extrémité)
 
@@ -76,8 +76,6 @@ Extension de l'expérimentation précédente avec plusieurs nœuds récepteurs s
 
 - http://modelrail.otenko.com/arduino/arduino-controller-area-network-can
 
-- http://www.seeedstudio.com/wiki/CAN-BUS_Shield
-
-- http://skpang.co.uk/blog/archives/55
+- https://web.archive.org/web/20160803041145/http://www.seeedstudio.com/wiki/CAN-BUS_Shield (archive.org 2016-08)
 
 - https://www.sparkfun.com/products/10039

--- a/site/docs/projets-du-lab/labanque.md
+++ b/site/docs/projets-du-lab/labanque.md
@@ -43,10 +43,6 @@ Tout temps consacré à faire vivre la communauté est compensé en ⬡.
 
 Si une personne souhaite utiliser les services du LAB avant d'avoir donné de son temps, elle a la possibilité d'acheter des ⬡ (100 ⬡ = 8 €).
 
-### Tout le monde en parle
-
-- [Le Fab Shop](http://www.lefabshop.fr/nutsbank-une-monnaie-pour-les-makers/)
-
 ### Comment gagner des ⬡ ?
 
 - En donnant du temps à l'association
@@ -105,6 +101,3 @@ Coût des ateliers de formation :
 | Atelier d'initiation de 2 h | 50 ⬡ |
 | Atelier de formation | 400 ⬡/0,5 j |
 
-### Protocole d'échange
-
-http://nutsbank.herokuapp.com/makers/sign_in

--- a/site/docs/projets-du-lab/terrarium-dendrobate.md
+++ b/site/docs/projets-du-lab/terrarium-dendrobate.md
@@ -183,7 +183,7 @@ Ce projet est encore à l'état de prototype, mais depuis fin août 2015, il hé
 
 - Projet DomoDuLAB
 
-- [Site du projet Internet Of Frogs](http://www.internet-of-frogs.com/)
+- [Site du projet Internet Of Frogs (archive.org 2016-03)](https://web.archive.org/web/20160318213229/http://www.internet-of-frogs.com/)
 
 - [Github du projet](https://github.com/carole-laitong/InternetOfFrogs)
 

--- a/site/docs/projets-du-lab/xylorobot.md
+++ b/site/docs/projets-du-lab/xylorobot.md
@@ -13,7 +13,7 @@ sidebar_position: 10
 
 ### Présentation
 
-XyloRobot est un glockenspiel à commande numérique, construit à partir du Kit Music Robot v2.0 (page d'origine plus en ligne, kit retiré du catalogue) de [MakeBlock](https://www.makeblock.com/). Le projet a été présenté lors de la conférence [Devoxx](http://www.devoxx.fr/) à Paris du 16 au 18 avril 2014. La démonstration a été un succès ; le projet se poursuit pour corriger les défauts du système d'origine.
+XyloRobot est un glockenspiel à commande numérique, construit à partir du Kit Music Robot v2.0 (page d'origine n'est plus en ligne, kit retiré du catalogue) de [MakeBlock](https://www.makeblock.com/). Le projet a été présenté lors de la conférence [Devoxx](http://www.devoxx.fr/) à Paris du 16 au 18 avril 2014. La démonstration a été un succès ; le projet se poursuit pour corriger les défauts du système d'origine.
 
 </div>
 

--- a/site/docs/projets-du-lab/xylorobot.md
+++ b/site/docs/projets-du-lab/xylorobot.md
@@ -13,7 +13,7 @@ sidebar_position: 10
 
 ### Présentation
 
-XyloRobot est un glockenspiel à commande numérique, construit à partir du [Kit Music Robot v2.0](http://www.makeblock.cc/music-robot-kit-v2-0-with-electronics/) de [MakeBlock](http://www.makeblock.cc/). Le projet a été présenté lors de la conférence [Devoxx](http://www.devoxx.fr/) à Paris du 16 au 18 avril 2014. La démonstration a été un succès ; le projet se poursuit pour corriger les défauts du système d'origine.
+XyloRobot est un glockenspiel à commande numérique, construit à partir du Kit Music Robot v2.0 (page d'origine plus en ligne, kit retiré du catalogue) de [MakeBlock](https://www.makeblock.com/). Le projet a été présenté lors de la conférence [Devoxx](http://www.devoxx.fr/) à Paris du 16 au 18 avril 2014. La démonstration a été un succès ; le projet se poursuit pour corriger les défauts du système d'origine.
 
 </div>
 
@@ -59,6 +59,6 @@ Le programme embarqué d'origine (MusicRobot) est en cours de remplacement par X
 
 ### Bibliographie
 
-- [Kit Music Robot — MakeBlock](http://www.makeblock.cc/music-robot-kit-v2-0-with-electronics/)
+- [MakeBlock (catalogue actuel)](https://www.makeblock.com/) — le kit Music Robot v2.0 utilisé pour le projet n'est plus en catalogue
 - [Dépôt GitHub XyloRobot](https://github.com/FraDiavolo7/XyloRobot)
 - [Devoxx France](http://www.devoxx.fr/)


### PR DESCRIPTION
Triage de 11 liens cassés sur 5 fiches de `projets-du-lab` (#71).

| Fiche | Liens | Action |
|---|---|---|
| `audio-hifi.md` | 3 (rtaylor DNS, audiolalies x2 404) | archive.org |
| `decouverte-bus-can.md` | 3 (seeedstudio 404, botshop 404, skpang 404 sans archive) | 2 archive.org + 1 ligne retirée |
| `labanque.md` | 2 (lefabshop 403, nutsbank.herokuapp 404 — Heroku free tier mort) | 2 sections retirées (NO_ARCHIVE pour les 2) |
| `terrarium-dendrobate.md` | 1 (internet-of-frogs DNS) | archive.org |
| `xylorobot.md` | 2 (makeblock.cc TLD migration + kit retiré) | racine makeblock.com + note clarifiant le retrait du kit |

Refs #71