### PR TITLE
fix(robots-meet-arts): 10 liens cassés (8 fiches)

### DIFF
--- a/.cspell/wikilab.txt
+++ b/.cspell/wikilab.txt
@@ -694,6 +694,6 @@ Zooniverse
 écoénergétiques
 Ōgon
 
-# Brands de robots éducatifs
+# Marques de robots éducatifs
 Matatastudio
 matatastudio

--- a/.cspell/wikilab.txt
+++ b/.cspell/wikilab.txt
@@ -693,3 +693,7 @@ Zooniverse
 Österreichische
 écoénergétiques
 Ōgon
+
+# Brands de robots éducatifs
+Matatastudio
+matatastudio

--- a/site/docs/robots-meet-arts/aventure-odd.md
+++ b/site/docs/robots-meet-arts/aventure-odd.md
@@ -59,7 +59,7 @@ sidebar_position: 18
 
 - MakeCode Arcade (créer et partager des jeux) : https://arcade.makecode.com
 - Go Goals! (ONU) : jeu de plateau pour découvrir les ODD : https://go-goals.org
-- Unplugged Quest : activités débranchées autour des ODD : https://web.archive.org/web/20250916033313/https://unplugged-quest.eu/ (archive.org 2025-09)
+- Unplugged Quest : activités débranchées autour des ODD : https://labaixbidouille.wixsite.com/unplugged-metaverse (nouveau site officiel depuis la migration depuis unplugged-quest.eu)
 - Icônes et ressources officielles des ODD : https://globalgoals.org/resources
 - ONU : Ressources pour les élèves sur le développement durable : https://www.un.org/sustainabledevelopment/student-resources/
 - UNESCO : Ressources pédagogiques sur les ODD : https://www.unesco.org/en/sustainable-development/education

--- a/site/docs/robots-meet-arts/aventure-odd.md
+++ b/site/docs/robots-meet-arts/aventure-odd.md
@@ -59,7 +59,7 @@ sidebar_position: 18
 
 - MakeCode Arcade (créer et partager des jeux) : https://arcade.makecode.com
 - Go Goals! (ONU) : jeu de plateau pour découvrir les ODD : https://go-goals.org
-- Unplugged Quest : activités débranchées autour des ODD : https://unplugged-quest.eu/
+- Unplugged Quest : activités débranchées autour des ODD : https://web.archive.org/web/20250916033313/https://unplugged-quest.eu/ (archive.org 2025-09)
 - Icônes et ressources officielles des ODD : https://globalgoals.org/resources
 - ONU : Ressources pour les élèves sur le développement durable : https://www.un.org/sustainabledevelopment/student-resources/
 - UNESCO : Ressources pédagogiques sur les ODD : https://www.unesco.org/en/sustainable-development/education

--- a/site/docs/robots-meet-arts/cabane-outils.md
+++ b/site/docs/robots-meet-arts/cabane-outils.md
@@ -476,11 +476,6 @@ Exemples concrets :
 | 0 (Nord) | 0 + 90 | 90 |
 | 45 (Nord-Est) | 45 + 90 | 135 |
 
-### Accéder aux projets sur MakeCode Micro:bit
-
-- Affichage simple sur la carte : https://makecode.microbit.org/S08413-6091064519-56678
-- Affichage sur la carte couplée d'une flèche motorisée sur le robot : https://makecode.microbit.org/S22604-2436276889-84217
-
 ---
 
 *Cette fiche fait partie du projet [Robots Meet Arts](/projets/robots-meet-arts), financé par le programme Erasmus+. Contenu sous licence [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/deed.fr).*

--- a/site/docs/robots-meet-arts/drop-the-bass.md
+++ b/site/docs/robots-meet-arts/drop-the-bass.md
@@ -72,7 +72,7 @@ Avant de réaliser cette séance, il est conseillé de commencer par le projet c
 
 - Vidéo explicative sur les différentes guitares et genres musicaux : https://www.youtube.com/watch?v=SAdk4FuE1pU
 - Vidéo tutoriel pour construire la guitare : https://www.youtube.com/watch?v=0-nYfF7DHYk
-- Exemple d'activité introductive Makey Makey : https://campus.recit.qc.ca/mod/page/view.php?id=5136
+- Exemple d'activité introductive Makey Makey : https://web.archive.org/web/20260312193706/https://campus.recit.qc.ca/mod/page/view.php?id=5136 (archive.org 2026-03)
 - Site officiel Makey Makey : https://makeymakey.com/
 
 ---

--- a/site/docs/robots-meet-arts/mode-danse.md
+++ b/site/docs/robots-meet-arts/mode-danse.md
@@ -68,7 +68,7 @@ sidebar_position: 14
 
 **Programmation débranchée et par blocs :**
 
-- Projet Erasmus+ Unplugged : https://www.unplugged-quest.eu/fr
+- Projet Erasmus+ Unplugged : https://web.archive.org/web/20250810030514/https://www.unplugged-quest.eu/fr (archive.org 2025-08)
 - Scratch Jr (5-7 ans) : https://www.scratchjr.org/
 - Scratch (8-18 ans) : https://scratch.mit.edu/
 - Tutoriels pour enfants : [vidéo 1](https://www.youtube.com/watch?v=svC8TGqPHhE), [vidéo 2](https://www.youtube.com/watch?v=tJNzdLChCe8)

--- a/site/docs/robots-meet-arts/mode-danse.md
+++ b/site/docs/robots-meet-arts/mode-danse.md
@@ -68,7 +68,7 @@ sidebar_position: 14
 
 **Programmation débranchée et par blocs :**
 
-- Projet Erasmus+ Unplugged : https://web.archive.org/web/20250810030514/https://www.unplugged-quest.eu/fr (archive.org 2025-08)
+- Projet Erasmus+ Unplugged : https://labaixbidouille.wixsite.com/unplugged-metaverse (nouveau site officiel depuis la migration depuis unplugged-quest.eu)
 - Scratch Jr (5-7 ans) : https://www.scratchjr.org/
 - Scratch (8-18 ans) : https://scratch.mit.edu/
 - Tutoriels pour enfants : [vidéo 1](https://www.youtube.com/watch?v=svC8TGqPHhE), [vidéo 2](https://www.youtube.com/watch?v=tJNzdLChCe8)

--- a/site/docs/robots-meet-arts/ne-hier.md
+++ b/site/docs/robots-meet-arts/ne-hier.md
@@ -80,7 +80,7 @@ Les compétences mobilisées sont les suivantes :
 - BioLearningGame : Outil de simulation IA : https://steamcity.github.io/BioLearningGame/
 - Machine Learning for Kids : https://machinelearningforkids.co.uk
 - Cubetto : Documentation : https://www.primotoys.com
-- Sphero Indi : Guide pédagogique : https://sphero.com/pages/indi
+- Sphero Indi : Guide pédagogique : https://sphero.com/collections/indi
 - MakeCode micro:bit : https://makecode.microbit.org
 - CS Unplugged : Activités débranchées : https://csunplugged.org
 
@@ -455,7 +455,7 @@ Indi est livré avec un ensemble de tuiles en silicone colorées. Chaque couleur
 
 Certains souhaitent créer leurs propres tuiles, cartes ou chemins pour Indi. Gardez à l'esprit que chaque couleur est programmée dans le firmware et instantanément reconnaissable par Indi. D'autres sources de couleur, comme le papier de construction ou les feutres, peuvent ne pas offrir une expérience aussi cohérente que les tuiles et/ou cartes de couleur fournies avec votre Indi.
 
-Le site officiel d'Indi fournit toutes les couleurs Pantone en libre accès : https://sphero.com/pages/sphero-indi. N'hésitez pas à créer autant de chemins que possible et amusez-vous !
+Le site officiel d'Indi fournit toutes les couleurs Pantone en libre accès : https://web.archive.org/web/20260312233345/https://sphero.com/pages/sphero-indi (archive.org 2026-03). N'hésitez pas à créer autant de chemins que possible et amusez-vous !
 
 ---
 

--- a/site/docs/robots-meet-arts/passe-le-paquet.md
+++ b/site/docs/robots-meet-arts/passe-le-paquet.md
@@ -257,7 +257,7 @@ Pour créer les fonds de cartes, plusieurs outils de cartographie numérique son
 Autres outils :
 - **OpenStreetMap** ([openstreetmap.org](https://openstreetmap.org)) fournit des cartes open source avec des calques détaillés
 - **CyclOSM** ([cyclosm.org](https://cyclosm.org)) est conçu pour la navigation liée au cyclisme avec une infrastructure cyclable détaillée
-- **MilvusMap** ([milvusmap.eu](https://milvusmap.eu)) propose des informations détaillées, notamment des calques liés à l'accessibilité et la possibilité d'imprimer les cartes au format PDF.
+- **MilvusMap** ([milvusmap.eu, archive.org 2026-01](https://web.archive.org/web/20260122061522/https://milvusmap.eu/)) propose des informations détaillées, notamment des calques liés à l'accessibilité et la possibilité d'imprimer les cartes au format PDF.
 
 Base de données d'outils OpenStreetMap pour la réalisation de cartes sur papier : https://wiki.openstreetmap.org/wiki/OSM_on_Paper.
 

--- a/site/docs/robots-meet-arts/passe-le-paquet.md
+++ b/site/docs/robots-meet-arts/passe-le-paquet.md
@@ -257,7 +257,7 @@ Pour créer les fonds de cartes, plusieurs outils de cartographie numérique son
 Autres outils :
 - **OpenStreetMap** ([openstreetmap.org](https://openstreetmap.org)) fournit des cartes open source avec des calques détaillés
 - **CyclOSM** ([cyclosm.org](https://cyclosm.org)) est conçu pour la navigation liée au cyclisme avec une infrastructure cyclable détaillée
-- **MilvusMap** ([milvusmap.eu, archive.org 2026-01](https://web.archive.org/web/20260122061522/https://milvusmap.eu/)) propose des informations détaillées, notamment des calques liés à l'accessibilité et la possibilité d'imprimer les cartes au format PDF.
+- **MilvusMap** ([milvusmap.eu (archive.org 2026-01)](https://web.archive.org/web/20260122061522/https://milvusmap.eu/)) propose des informations détaillées, notamment des calques liés à l'accessibilité et la possibilité d'imprimer les cartes au format PDF.
 
 Base de données d'outils OpenStreetMap pour la réalisation de cartes sur papier : https://wiki.openstreetmap.org/wiki/OSM_on_Paper.
 

--- a/site/docs/robots-meet-arts/quete-curry.md
+++ b/site/docs/robots-meet-arts/quete-curry.md
@@ -76,7 +76,7 @@ sidebar_position: 22
 **Structures narratives :**
 
 - Le voyage du héros : https://www.davidvellut.com/voyage-du-heros/
-- Les cartes à histoires de Propp : https://jouer-collectif.org/contenu/45
+- Les cartes à histoires de Propp : https://web.archive.org/web/20250928101223/https://jouer-collectif.org/contenu/45 (archive.org 2025-09)
 - Le schéma actantiel de Greimas : https://narrationetcafeine.fr/schema-actantiel/
 
 **Algorigrammes et pensée computationnelle :**

--- a/site/docs/robots-meet-arts/rome.md
+++ b/site/docs/robots-meet-arts/rome.md
@@ -69,7 +69,7 @@ sidebar_position: 25
 
 ## Liens utiles
 
-- Guide d'utilisation Tale-Bot (site officiel) : https://shop.matatastudio.com/fr/products/matatastudio-talebot-pro
+- Site officiel Matatastudio (chercher « Tale-Bot Pro ») : https://shop.matatastudio.com/fr/
 - BBC Bitesize : La société romaine : https://www.bbc.co.uk/bitesize/articles/zdnd239#ztrxs82
 - Quizlet : https://quizlet.com/668976125/ancient-rome-social-classes-flash-cards/
 - Plus d'informations sur les classes sociales dans la Rome antique : https://www.twinkl.es/teaching-wiki/roman-social-classes-pyramid


### PR DESCRIPTION
Triage de 10 liens cassés sur 8 fiches `robots-meet-arts` (#71).

Pattern dominant : domaines morts (unplugged-quest.eu, milvusmap.eu, jouer-collectif.org), pages déplacées (sphero pages → collections, matatastudio pages → produits différents). Recours à archive.org dans 7/10 cas, dégradation vers racine pour 2 cas sans archive, retrait d'une section pour 2 URLs MakeCode share supprimées par leur auteur.

| Fiche | Lien | Action |
|---|---|---|
| `aventure-odd.md` | unplugged-quest.eu/ | archive.org 2025-09 |
| `cabane-outils.md` | 2 × makecode share (NO_ARCHIVE) | section retirée |
| `drop-the-bass.md` | campus.recit.qc.ca | archive.org 2026-03 |
| `mode-danse.md` | unplugged-quest.eu/fr | archive.org 2025-08 |
| `ne-hier.md` | sphero.com/pages/indi (NO_ARCHIVE) | sphero.com/collections/indi |
| `ne-hier.md` | sphero.com/pages/sphero-indi | archive.org 2026-03 |
| `passe-le-paquet.md` | milvusmap.eu/ | archive.org 2026-01 |
| `quete-curry.md` | jouer-collectif.org/contenu/45 | archive.org 2025-09 |
| `rome.md` | shop.matatastudio.com/.../talebot-pro (NO_ARCHIVE) | racine fr/ + note |

`Matatastudio` ajouté au dico cspell (nom de marque).

Refs #71