### PR TITLE
refactor(code): couleur de header de tableau pilotée par projet

### DIFF
--- a/site/src/css/custom.css
+++ b/site/src/css/custom.css
@@ -220,10 +220,51 @@ article li,
   border-collapse: collapse;
 }
 
+/* Couleur de fond du `thead` : pilotée par projet via la variable
+ * `--wiki-table-thead-bg`. La valeur par défaut (#09246c, bleu Mimesis)
+ * reste appliquée si aucun projet n'est détecté. Les overrides projet
+ * sont définis plus bas via le sélecteur `[class*="docs-doc-id-<projet>/"]`
+ * que Docusaurus ajoute au wrapper de chaque page de fiche.
+ *
+ * Source des couleurs : `site/src/data/projects.ts` (champ `color`). */
 .markdown table thead th {
-  background-color: #09246c;
+  background-color: var(--wiki-table-thead-bg, #09246c);
   color: #fff !important;
   font-weight: 700;
+}
+
+[class*='docs-doc-id-lets-steam/'] {
+  --wiki-table-thead-bg: #140e4e;
+}
+[class*='docs-doc-id-mimesis/'] {
+  --wiki-table-thead-bg: #09246c;
+}
+[class*='docs-doc-id-robots-meet-arts/'] {
+  --wiki-table-thead-bg: #169da7;
+}
+[class*='docs-doc-id-steamcity/'] {
+  --wiki-table-thead-bg: #dd5350;
+}
+[class*='docs-doc-id-unplugged/'] {
+  --wiki-table-thead-bg: #0081a7;
+}
+[class*='docs-doc-id-jeditrack/'] {
+  --wiki-table-thead-bg: #1198f0;
+}
+[class*='docs-doc-id-thedexterlab/'] {
+  --wiki-table-thead-bg: #1a4a48;
+}
+[class*='docs-doc-id-youth-ai-lab/'] {
+  --wiki-table-thead-bg: #b34520;
+}
+[class*='docs-doc-id-magnetics/'] {
+  --wiki-table-thead-bg: #094869;
+}
+[class*='docs-doc-id-inovmicro-exao/'] {
+  --wiki-table-thead-bg: #8a6e18;
+}
+[class*='docs-doc-id-projets-du-lab/'] {
+  --wiki-table-thead-bg: #356bac;
 }
 
 .markdown table td,


### PR DESCRIPTION
## Résumé

Le `background-color` du `<th>` des tableaux de fiches était figé sur `#09246c` (couleur Mimesis), peu importe le projet. Du coup une fiche Let's STEAM, SteamCity, JediTrack, etc. affichait toujours un en-tête bleu Mimesis — incohérent avec leur identité visuelle. Dette listée dans `CLAUDE.md` (« Travaux en cours »).

## Implémentation

- Introduit la variable CSS `--wiki-table-thead-bg` avec `#09246c` en fallback (pour les pages hors fiche projet : catalogue, projets, machines, etc.).
- Surcharge la variable par projet via le sélecteur `[class*="docs-doc-id-<projet>/"]` que Docusaurus appose déjà sur le wrapper `docs-wrapper` de chaque page de fiche.
- Les 11 projets pointent leur valeur tirée de `site/src/data/projects.ts` (champ `color`).

| Projet | Couleur |
|---|---|
| lets-steam | `#140e4e` |
| mimesis | `#09246c` (inchangé) |
| robots-meet-arts | `#169da7` |
| steamcity | `#dd5350` |
| unplugged | `#0081a7` |
| jeditrack | `#1198f0` |
| thedexterlab | `#1a4a48` |
| youth-ai-lab | `#b34520` |
| magnetics | `#094869` |
| inovmicro-exao | `#8a6e18` |
| projets-du-lab | `#356bac` |

## Notes

- **Source de vérité** : `projects.ts`. Si une couleur change, mettre à jour le `.css` en miroir (pas de génération automatique pour rester sur du CSS statique compatible Docusaurus).
- **Pas de risque de régression sur le fallback** : les pages non-docs (catalogue, projets, machines) ne portent pas la classe `docs-doc-id-*` et utilisent donc le fallback `#09246c`, identique au comportement actuel.

## Test plan

- [x] `npm run site:build` — passe
- [x] Classes `docs-doc-id-<projet>/` vérifiées présentes sur 3 pages-types du bundle (lets-steam, jeditrack, inovmicro-exao)
- [x] Règles CSS vérifiées présentes dans `build/assets/css/styles.*.css`
- [ ] **Revue visuelle humaine** : ouvrir une fiche par projet et vérifier la couleur du `thead` (impossible automatiquement, c'est du rendu navigateur)