### PR TITLE
refactor(inovmicro-exao): groupe la page projet par section

### DIFF
--- a/site/src/components/ProjectPage/index.tsx
+++ b/site/src/components/ProjectPage/index.tsx
@@ -11,11 +11,82 @@ import {
   type Resource,
 } from '../../data/resources';
 
+function renderResourceCard(r: Resource): React.ReactElement {
+  return (
+    <Link key={r.id} to={r.slug} className="card wikilab-project-resource-card">
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '0.75rem',
+          marginBottom: '0.5rem',
+        }}
+      >
+        {r.thumbnail && (
+          <img
+            src={r.thumbnail}
+            alt=""
+            style={{
+              width: '45px',
+              height: '45px',
+              objectFit: 'contain',
+              flexShrink: 0,
+            }}
+          />
+        )}
+        <h3 style={{ margin: 0 }}>{r.title}</h3>
+      </div>
+      <p>{r.summary}</p>
+      <div className="wikilab-project-resource-card__meta">
+        {r.ageMin}–{r.ageMax} ans · {r.durationMinutes} min · {difficultyLabels[r.difficulty]}
+      </div>
+      <div className="wikilab-project-resource-card__badges">
+        {r.disciplines.map((d) => (
+          <span key={d} className="badge badge--primary">
+            {disciplineLabels[d]}
+          </span>
+        ))}
+        {r.tools.map((t) => (
+          <span key={t} className="badge badge--info">
+            {toolLabels[t]}
+          </span>
+        ))}
+        {r.software.map((s) => (
+          <span key={s} className="badge badge--warning">
+            {softwareLabels[s]}
+          </span>
+        ))}
+      </div>
+    </Link>
+  );
+}
+
 export default function ProjectPage({ project }: { project: ProjectInfo }): React.ReactElement {
   const projectResources = useMemo<Resource[]>(
     () => resources.filter((r) => r.project === project.id),
     [project.id],
   );
+
+  // Si au moins une ressource du projet porte un champ `section`, on
+  // groupe par section au lieu d'afficher une liste plate. L'ordre des
+  // sections est celui de leur première apparition dans `resources` ;
+  // les ressources sans section partent dans une catégorie "Autres
+  // ressources" à la fin.
+  const sectionedResources = useMemo<{ name: string; items: Resource[] }[] | null>(() => {
+    const hasSections = projectResources.some((r) => r.section);
+    if (!hasSections) return null;
+    const order: string[] = [];
+    const buckets = new Map<string, Resource[]>();
+    for (const r of projectResources) {
+      const key = r.section ?? 'Autres ressources';
+      if (!buckets.has(key)) {
+        buckets.set(key, []);
+        order.push(key);
+      }
+      buckets.get(key)!.push(r);
+    }
+    return order.map((name) => ({ name, items: buckets.get(name)! }));
+  }, [projectResources]);
 
   const countries = useMemo(() => {
     const set = new Set(project.partners.map((p) => p.country));
@@ -208,56 +279,18 @@ export default function ProjectPage({ project }: { project: ProjectInfo }): Reac
             <div className="wikilab-project-empty">
               Les ressources de ce projet seront bientôt disponibles.
             </div>
+          ) : sectionedResources ? (
+            sectionedResources.map((s) => (
+              <div key={s.name} className="wikilab-project-section-group">
+                <h3 className="wikilab-project-section-group__title">{s.name}</h3>
+                <div className="wikilab-project-resources">
+                  {s.items.map((r) => renderResourceCard(r))}
+                </div>
+              </div>
+            ))
           ) : (
             <div className="wikilab-project-resources">
-              {projectResources.map((r) => (
-                <Link key={r.id} to={r.slug} className="card wikilab-project-resource-card">
-                  <div
-                    style={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      gap: '0.75rem',
-                      marginBottom: '0.5rem',
-                    }}
-                  >
-                    {r.thumbnail && (
-                      <img
-                        src={r.thumbnail}
-                        alt=""
-                        style={{
-                          width: '45px',
-                          height: '45px',
-                          objectFit: 'contain',
-                          flexShrink: 0,
-                        }}
-                      />
-                    )}
-                    <h3 style={{ margin: 0 }}>{r.title}</h3>
-                  </div>
-                  <p>{r.summary}</p>
-                  <div className="wikilab-project-resource-card__meta">
-                    {r.ageMin}–{r.ageMax} ans · {r.durationMinutes} min ·{' '}
-                    {difficultyLabels[r.difficulty]}
-                  </div>
-                  <div className="wikilab-project-resource-card__badges">
-                    {r.disciplines.map((d) => (
-                      <span key={d} className="badge badge--primary">
-                        {disciplineLabels[d]}
-                      </span>
-                    ))}
-                    {r.tools.map((t) => (
-                      <span key={t} className="badge badge--info">
-                        {toolLabels[t]}
-                      </span>
-                    ))}
-                    {r.software.map((s) => (
-                      <span key={s} className="badge badge--warning">
-                        {softwareLabels[s]}
-                      </span>
-                    ))}
-                  </div>
-                </Link>
-              ))}
+              {projectResources.map((r) => renderResourceCard(r))}
             </div>
           )}
 

--- a/site/src/components/ProjectPage/index.tsx
+++ b/site/src/components/ProjectPage/index.tsx
@@ -11,7 +11,12 @@ import {
   type Resource,
 } from '../../data/resources';
 
-function renderResourceCard(r: Resource): React.ReactElement {
+// `titleLevel` permet d'imbriquer correctement les titres de fiche sous
+// un titre de section (h3) : on passe `h4` pour la navigation lecteur
+// d'écran et l'outline du document. Quand les ressources sont en liste
+// plate (sous le h2 « Ressources »), on garde `h3`.
+function renderResourceCard(r: Resource, titleLevel: 'h3' | 'h4' = 'h3'): React.ReactElement {
+  const TitleTag = titleLevel;
   return (
     <Link key={r.id} to={r.slug} className="card wikilab-project-resource-card">
       <div
@@ -34,7 +39,7 @@ function renderResourceCard(r: Resource): React.ReactElement {
             }}
           />
         )}
-        <h3 style={{ margin: 0 }}>{r.title}</h3>
+        <TitleTag style={{ margin: 0 }}>{r.title}</TitleTag>
       </div>
       <p>{r.summary}</p>
       <div className="wikilab-project-resource-card__meta">
@@ -69,22 +74,27 @@ export default function ProjectPage({ project }: { project: ProjectInfo }): Reac
 
   // Si au moins une ressource du projet porte un champ `section`, on
   // groupe par section au lieu d'afficher une liste plate. L'ordre des
-  // sections est celui de leur première apparition dans `resources` ;
-  // les ressources sans section partent dans une catégorie "Autres
-  // ressources" à la fin.
+  // sections nommées est celui de leur première apparition dans
+  // `resources` ; les ressources sans section sont collectées dans une
+  // catégorie « Autres ressources » qui est forcée en dernier, quel
+  // que soit l'ordre d'apparition (cas migration partielle : une fiche
+  // sans `section` peut précéder une fiche avec `section` dans la
+  // liste).
   const sectionedResources = useMemo<{ name: string; items: Resource[] }[] | null>(() => {
     const hasSections = projectResources.some((r) => r.section);
     if (!hasSections) return null;
-    const order: string[] = [];
+    const FALLBACK = 'Autres ressources';
+    const namedOrder: string[] = [];
     const buckets = new Map<string, Resource[]>();
     for (const r of projectResources) {
-      const key = r.section ?? 'Autres ressources';
+      const key = r.section ?? FALLBACK;
       if (!buckets.has(key)) {
         buckets.set(key, []);
-        order.push(key);
+        if (key !== FALLBACK) namedOrder.push(key);
       }
       buckets.get(key)!.push(r);
     }
+    const order = buckets.has(FALLBACK) ? [...namedOrder, FALLBACK] : namedOrder;
     return order.map((name) => ({ name, items: buckets.get(name)! }));
   }, [projectResources]);
 
@@ -284,7 +294,7 @@ export default function ProjectPage({ project }: { project: ProjectInfo }): Reac
               <div key={s.name} className="wikilab-project-section-group">
                 <h3 className="wikilab-project-section-group__title">{s.name}</h3>
                 <div className="wikilab-project-resources">
-                  {s.items.map((r) => renderResourceCard(r))}
+                  {s.items.map((r) => renderResourceCard(r, 'h4'))}
                 </div>
               </div>
             ))

--- a/site/src/css/custom.css
+++ b/site/src/css/custom.css
@@ -683,7 +683,8 @@ article > table:first-of-type {
   color: var(--ifm-color-primary-darkest);
 }
 
-.wikilab-project-resource-card h3 {
+.wikilab-project-resource-card h3,
+.wikilab-project-resource-card h4 {
   color: var(--ifm-color-primary-darkest);
 }
 
@@ -826,7 +827,8 @@ article > table:first-of-type {
   color: inherit !important;
 }
 
-.wikilab-project-resource-card h3 {
+.wikilab-project-resource-card h3,
+.wikilab-project-resource-card h4 {
   margin-top: 0;
   font-size: 1.05rem;
 }

--- a/site/src/css/custom.css
+++ b/site/src/css/custom.css
@@ -802,6 +802,24 @@ article > table:first-of-type {
   gap: 1rem;
 }
 
+/* Groupes de ressources par section (projets avec ≥10 fiches structurées
+ * — voir le champ optionnel `Resource.section`). */
+.wikilab-project-section-group {
+  margin-top: 1.5rem;
+}
+
+.wikilab-project-section-group:first-of-type {
+  margin-top: 0.5rem;
+}
+
+.wikilab-project-section-group__title {
+  font-size: 1.2rem;
+  margin: 0 0 0.75rem 0;
+  padding-bottom: 0.35rem;
+  border-bottom: 2px solid var(--project-color, var(--ifm-color-primary));
+  color: var(--project-color, var(--ifm-color-primary));
+}
+
 .wikilab-project-resource-card {
   padding: 1rem;
   text-decoration: none !important;

--- a/site/src/data/resources.ts
+++ b/site/src/data/resources.ts
@@ -96,6 +96,14 @@ export interface Resource {
   // Défaut implicite 0 → ordre alphabétique naturel. Valeur élevée
   // (ex. 99) pour les pages transverses qui doivent rester en bas.
   sidebarOrder?: number;
+  // Sous-section d'affichage sur la page projet. Quand au moins une
+  // ressource d'un projet porte ce champ, la page projet groupe les
+  // ressources par section au lieu de les afficher en liste plate.
+  // L'ordre des sections est dérivé de leur ordre de première
+  // apparition dans `resources`. Utile pour les projets avec ≥10
+  // fiches structurées (ex. I-NOVMICRO : Découverte / Prise en main /
+  // Apprentissage / Ressources transverses).
+  section?: string;
 }
 
 export const resources: Resource[] = [
@@ -3672,6 +3680,7 @@ export const resources: Resource[] = [
     categories: ['programmation', 'exploration-scientifique'],
     keywords: ['STeaMi', 'STM32', 'MicroPython', 'MakeCode', 'IoT', 'capteurs', 'BLE'],
     thumbnail: '/img/ressources/inovmicro-exao/decouverte-steami/icone.png',
+    section: 'Découverte',
   },
   {
     id: 'i10-texte-oled',
@@ -3700,6 +3709,7 @@ export const resources: Resource[] = [
       'affichage',
     ],
     thumbnail: '/img/ressources/inovmicro-exao/i10-texte-oled/icone.png',
+    section: 'Apprentissage de la programmation',
   },
   {
     id: 't03-decouverte-thonny',
@@ -3719,6 +3729,7 @@ export const resources: Resource[] = [
     categories: ['programmation'],
     keywords: ['STeaMi', 'MicroPython', 'Thonny', 'REPL', 'éditeur', 'desktop'],
     thumbnail: '/img/ressources/inovmicro-exao/t03-decouverte-thonny/Thonny.png',
+    section: 'Prise en main',
   },
   {
     id: 'i04-capteur-lumiere',
@@ -3738,6 +3749,7 @@ export const resources: Resource[] = [
     categories: ['programmation', 'exploration-scientifique'],
     keywords: ['STeaMi', 'MicroPython', 'capteur', 'lumière', 'APDS-9960', 'I2C'],
     thumbnail: '/img/ressources/inovmicro-exao/i04-capteur-lumiere/icone.png',
+    section: 'Apprentissage de la programmation',
   },
   {
     id: 'i06-code-morse',
@@ -3757,6 +3769,7 @@ export const resources: Resource[] = [
     categories: ['programmation'],
     keywords: ['STeaMi', 'MicroPython', 'Morse', 'buzzer', 'piézo', 'codage'],
     thumbnail: '/img/ressources/inovmicro-exao/i06-code-morse/icone.png',
+    section: 'Apprentissage de la programmation',
   },
   {
     id: 'depannage',
@@ -3776,6 +3789,7 @@ export const resources: Resource[] = [
     categories: ['programmation'],
     keywords: ['STeaMi', 'MicroPython', 'dépannage', 'port série', 'IDE'],
     sidebarOrder: 99,
+    section: 'Ressources transverses',
   },
   {
     id: 'programmation-city-detective-challenge',


### PR DESCRIPTION
## Résumé

Préparation EPIC #2 : I-NOVMICRO va passer de 6 à 22+ fiches selon le plan en place ([#2](https://github.com/LabAixBidouille/wikilab/issues/2), 15 portages Let's STEAM + 7 fiches enseignants). Une liste plate de 22 cartes devient illisible — on regroupe par sous-section comme prévu en [#1](https://github.com/LabAixBidouille/wikilab/issues/1).

## Implémentation

- **Champ optionnel `section?: string`** sur `Resource` (`site/src/data/resources.ts`).
- **`ProjectPage`** groupe par section si au moins une ressource du projet en porte une ; sinon affichage en liste plate comme avant (backward compatible — les 10 autres projets ne changent pas).
- **Ordre des sections** : dérivé de leur première apparition dans `resources.ts` (pas d'order global pour rester déclaratif et simple).

## Sections actuelles (I-NOVMICRO)

| Section | Fiches (état actuel) |
|---|---|
| Découverte | decouverte-steami |
| Apprentissage de la programmation | i04, i06, i10 (→ futurs i01-i15) |
| Prise en main | t03-decouverte-thonny (→ futurs t01-t07) |
| Ressources transverses | depannage |

## Notes

- L'ordre courant (Découverte → Apprentissage → Prise en main → Transverses) reflète l'ordre de déclaration dans `resources.ts`. Il se réajustera naturellement quand les fiches t01-t07 seront déclarées au-dessus des i*, ou via tri explicite si besoin plus tard.
- CSS du titre de section : bordure inférieure colorée via `--project-color`, fallback `--ifm-color-primary`.

## Test plan

- [x] `npm run site:typecheck` — passe
- [x] `npm run site:build` — passe
- [x] 4 sections vérifiées présentes dans `build/projets/inovmicro-exao.html`
- [x] 3 autres pages projet (`lets-steam`, `jeditrack`, `steamcity`) ne contiennent **aucun** `wikilab-project-section-group__title` → fallback liste plate confirmé
- [ ] Revue visuelle humaine (rendu navigateur)