### PR TITLE
docs(inovmicro-exao): backporte le ton Let's STEAM sur i04-capteur-lumiere

### DIFF
--- a/site/docs/inovmicro-exao/i04-capteur-lumiere.md
+++ b/site/docs/inovmicro-exao/i04-capteur-lumiere.md
@@ -80,11 +80,11 @@ Contrairement à une photorésistance qui fournit une tension variable lue par u
 
 ### Connecter la carte à l'ordinateur
 
-Brancher la STeaMi à l'ordinateur via le câble USB. Si votre IDE MicroPython est déjà configuré (voir la fiche [Thonny : Prise en main de MicroPython](/ressources/inovmicro-exao/t03-decouverte-thonny) si vous démarrez), la console MicroPython doit afficher le prompt `>>>`.
+Brancher la STeaMi à l'ordinateur via le câble USB. Si votre IDE MicroPython est déjà configuré (voir la fiche [Thonny : Prise en main de MicroPython](/ressources/inovmicro-exao/t03-decouverte-thonny) si vous démarrez), la console MicroPython doit afficher `>>>` — c'est **l'invite** (parfois appelée « prompt » en anglais) : un signe qui apparaît en début de ligne pour vous dire que la console est prête à recevoir une commande.
 
 ### Vérifier que le capteur répond
 
-Avant d'écrire le programme principal, on peut vérifier dans le **REPL** que le capteur est bien détecté sur le bus I2C. Les `>>>` ci-dessous sont le prompt affiché par MicroPython dans la console pour indiquer qu'il attend une commande, ne les tapez pas, écrivez seulement ce qui suit.
+Avant d'écrire le programme principal, on peut vérifier que le capteur est bien détecté sur le bus I2C. Pour ça, on utilise la console MicroPython en mode interactif (appelé **REPL** pour _Read-Eval-Print Loop_ : on tape une commande, elle s'exécute, on voit le résultat, et la console attend la suivante). Les `>>>` ci-dessous sont l'invite affichée par la console pour signaler qu'elle attend votre commande : ne les tapez pas, écrivez seulement ce qui suit.
 
 ```python
 >>> from machine import I2C
@@ -210,11 +210,12 @@ La valeur de `SEUIL_CLAIR = 100` est arbitraire. Pour adapter le détecteur à u
 1. Lancer le programme dans la condition « sombre » visée (par exemple capteur recouvert) et noter la valeur lue.
 2. Faire de même dans la condition « claire » (lumière ambiante normale).
 3. Choisir comme seuil la moyenne des deux valeurs.
+
 Une amélioration plus avancée consiste à **transformer la valeur brute en pourcentage** par rapport à un minimum et un maximum mesurés, ce qui rend la mesure plus parlante.
 
 ### 2. Lire les composantes RGB de la lumière
 
-L'APDS-9960 ne se contente pas de mesurer la quantité de lumière : il mesure aussi ses **composantes rouge, verte et bleue**. C'est très différent, on peut, par exemple, distinguer la lumière d'une LED rouge de celle d'une LED verte, alors que la simple lecture de `ambient_light()` donnerait à peu près la même valeur dans les deux cas.
+L'APDS-9960 ne se contente pas de mesurer la quantité de lumière : il mesure aussi ses **composantes rouge, verte et bleue**. C'est une différence importante : alors que `ambient_light()` dit juste « il y a beaucoup ou peu de lumière », les canaux R, V, B disent **quelle couleur** est dominante. Le capteur peut donc distinguer la lumière d'une LED rouge de celle d'une LED verte, alors que `ambient_light()` donnerait à peu près la même valeur dans les deux cas.
 
 Les lignes ci-dessous remplacent l'appel à `ambient_light()` dans la boucle du programme précédent, `sensor` est déjà initialisé en haut de fichier.
 
@@ -247,10 +248,17 @@ else:
 
 ## Aller plus loin
 
-- [Documentation du driver APDS-9960 sur la STeaMi](https://github.com/steamicc/micropython-steami-lib/blob/main/lib/apds9960/README.md) : toutes les fonctions disponibles, y compris la proximité et les gestes.
-- [Fiche technique du capteur APDS-9960 (Broadcom)](https://www.broadcom.com/products/optical-sensors/integrated-ambient-light-and-proximity-sensors/apds-9960) : caractéristiques détaillées du composant.
-- [Wiki STeaMi : Capteurs internes](https://wiki.steami.cc/docs/hardware/) : liste de tous les capteurs présents sur la carte.
-- [Documentation MicroPython : module `machine.I2C`](https://docs.micropython.org/en/latest/library/machine.I2C.html) : pour comprendre comment fonctionne le bus I2C en MicroPython.
----
+### Pour comprendre
+
+- **[Photorésistance — Wikipedia](https://fr.wikipedia.org/wiki/Photor%C3%A9sistance)** : le composant cousin de l'APDS-9960. Plus simple : sa résistance change avec la lumière, et c'est tout. Beaucoup de capteurs de lumière débutants en utilisent.
+- **[Effet photoélectrique — Wikipedia](https://fr.wikipedia.org/wiki/Effet_photo%C3%A9lectrique)** : pourquoi la lumière fait du courant. C'est l'explication d'Einstein en 1905 qui lui a valu le prix Nobel — pas la relativité comme on le croit souvent.
+- **[L'œil humain — Wikipedia](https://fr.wikipedia.org/wiki/%C5%92il_humain)** : votre œil est un capteur de lumière biologique avec deux types de cellules (cônes pour la couleur, bâtonnets pour la nuit). C'est exactement le principe d'un capteur RGB comme l'APDS-9960, mais en chair et en os.
+
+### Pour s'inspirer
+
+- **[Public Lab — DIY spectromètre](https://publiclab.org/wiki/spectrometry)** : une communauté de scientifiques amateurs qui ont construit un spectromètre à partir d'un téléphone et d'un DVD. Sert à analyser la pollution de l'eau, identifier des matériaux, ou étudier la chlorophylle des plantes.
+- **[Éclairage public adaptatif (Cerema)](https://www.cerema.fr/fr/actualites/eclairage-public-adaptation-eclairage-presence)** : éteindre ou réduire les lampadaires quand la rue est vide, c'est exactement ce qu'on fait dans cette fiche, mais à l'échelle d'une ville. Économies d'énergie + moins de pollution lumineuse.
+- **[Photographier la Voie Lactée](https://www.lemonde.fr/blog/autourduciel/2020/05/22/photographier-la-voie-lactee-en-pause-longue/)** : avec des poses de plusieurs secondes ou minutes, un capteur photo accumule la lumière la plus faible — c'est comme cela que les astronomes amateurs photographient des galaxies invisibles à l'œil nu.
+- **[Sextant — Wikipedia](https://fr.wikipedia.org/wiki/Sextant)** : avant le GPS, les marins se repéraient en mesurant l'angle entre un astre et l'horizon. Une histoire fascinante d'instruments de mesure et de navigation.
 
 _Cette fiche fait partie du projet [I-Novmicro #2 : Action EXAO](/projets/inovmicro-exao). Adaptée du projet [Let's STEAM](/projets/lets-steam) (fiche [`r1as04-capteur-lumiere`](/ressources/lets-steam/r1as04-capteur-lumiere)) sous licence [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/deed.fr)._

--- a/site/docs/inovmicro-exao/i04-capteur-lumiere.md
+++ b/site/docs/inovmicro-exao/i04-capteur-lumiere.md
@@ -253,7 +253,7 @@ else:
 ### Pour comprendre
 
 - **[Photorésistance — Wikipedia](https://fr.wikipedia.org/wiki/Photor%C3%A9sistance)** : le composant cousin de l'APDS-9960. Plus simple : sa résistance change avec la lumière, et c'est tout. Beaucoup de capteurs de lumière débutants en utilisent.
-- **[Effet photoélectrique — Wikipedia](https://fr.wikipedia.org/wiki/Effet_photo%C3%A9lectrique)** : pourquoi la lumière fait du courant. C'est l'explication d'Einstein en 1905 qui lui a valu le prix Nobel — pas la relativité comme on le croit souvent.
+- **[Effet photoélectrique — Wikipedia](https://fr.wikipedia.org/wiki/Effet_photo%C3%A9lectrique)** : pourquoi la lumière fait du courant. C'est l'explication publiée par Einstein en 1905 qui lui a valu le prix Nobel de physique en 1921 — pas la relativité comme on le croit souvent.
 - **[L'œil humain — Wikipedia](https://fr.wikipedia.org/wiki/%C5%92il_humain)** : votre œil est un capteur de lumière biologique avec deux types de cellules (cônes pour la couleur, bâtonnets pour la nuit). C'est exactement le principe d'un capteur RGB comme l'APDS-9960, mais en chair et en os.
 
 ### Pour s'inspirer

--- a/site/docs/inovmicro-exao/i04-capteur-lumiere.md
+++ b/site/docs/inovmicro-exao/i04-capteur-lumiere.md
@@ -57,7 +57,7 @@ L'avantage du capteur intégré : pas de breadboard ni de câblage. Tout passe p
 
 Ici, "construire" est rapide : tout le matériel nécessaire est déjà sur la carte.
 
-### Localiser le capteur de lumière
+### 1. Localiser le capteur de lumière
 
 Le capteur **APDS-9960** est soudé sur la face avant de la STeaMi, près de l'écran OLED. Il n'a pas besoin d'être éclairé directement par une source : il mesure la **lumière ambiante** qui atteint sa petite fenêtre transparente.
 
@@ -78,11 +78,11 @@ Contrairement à une photorésistance qui fournit une tension variable lue par u
 
 :::
 
-### Connecter la carte à l'ordinateur
+### 2. Connecter la carte à l'ordinateur
 
 Brancher la STeaMi à l'ordinateur via le câble USB. Si votre IDE MicroPython est déjà configuré (voir la fiche [Thonny : Prise en main de MicroPython](/ressources/inovmicro-exao/t03-decouverte-thonny) si vous démarrez), la console MicroPython doit afficher `>>>` — c'est **l'invite** (parfois appelée « prompt » en anglais) : un signe qui apparaît en début de ligne pour vous dire que la console est prête à recevoir une commande.
 
-### Vérifier que le capteur répond
+### 3. Vérifier que le capteur répond
 
 Avant d'écrire le programme principal, on peut vérifier que le capteur est bien détecté sur le bus I2C. Pour ça, on utilise la console MicroPython en mode interactif (appelé **REPL** pour _Read-Eval-Print Loop_ : on tape une commande, elle s'exécute, on voit le résultat, et la console attend la suivante). Les `>>>` ci-dessous sont l'invite affichée par la console pour signaler qu'elle attend votre commande : ne les tapez pas, écrivez seulement ce qui suit.
 
@@ -93,13 +93,45 @@ Avant d'écrire le programme principal, on peut vérifier que le capteur est bie
 ['0x1e', '0x29', '0x39', '0x55', '0x5d', '0x5f', '0x6b']
 ```
 
-L'adresse `0x39` correspond à l'APDS-9960. Si elle apparaît, le capteur répond, on peut passer à la programmation.
+L'adresse `0x39` correspond à l'APDS-9960. Si elle apparaît, le capteur répond, on peut passer à la suite.
+
+### 4. Lancer le programme
+
+Notre premier programme va **lire la lumière ambiante toutes les demi-secondes et l'afficher dans la console**, en utilisant la LED RGB comme indicateur visuel (verte si lumière forte, rouge si sombre). Le code complet est donné à l'[Étape 2 : Programmer](#étape-2--programmer) ci-dessous — copiez-le dans votre IDE.
+
+Une fois le code en place, deux manières de le lancer :
+
+- **Test rapide** : lancer le programme depuis l'IDE (typiquement bouton **Run** ▶ ou `F5`). Les valeurs défilent dans la console MicroPython.
+- **Programme persistant** : enregistrer le fichier sous le nom **`main.py`** sur la carte. Il sera relancé à chaque démarrage.
+
+### 5. Observer les variations
+
+Une fois le programme lancé, plusieurs choses à essayer :
+
+- Couvrir le capteur avec la main : la valeur affichée chute, la LED devient rouge.
+- Approcher la carte d'une fenêtre ou d'une lampe : la valeur grimpe, la LED passe au vert.
+- Allumer la lampe d'un téléphone et la diriger vers le capteur : on voit clairement le seuil franchi.
+
+<figure style={{textAlign: 'center', margin: '1rem auto'}}>
+  <img
+    src="/img/ressources/inovmicro-exao/i04-capteur-lumiere/02-thonny-shell-mesures.png"
+    alt="Valeurs de lumière qui défilent dans la console MicroPython"
+    style={{maxWidth: '100%', height: 'auto'}}
+  />
+  <figcaption style={{fontStyle: 'italic', marginTop: '0.5rem'}}>
+    Les valeurs défilent dans la console MicroPython, et chutent quand on couvre le capteur.
+  </figcaption>
+</figure>
+
+:::info[Tracer un graphique (spécifique à Thonny)]
+
+Si vous utilisez Thonny, l'éditeur propose un **traceur de variables** : **Affichage → Plotter** (ou **View → Plotter**). Une fenêtre s'ouvre à côté de la console et trace en temps réel toutes les valeurs numériques affichées par `print()`. Pratique pour visualiser comment la lumière varie dans le temps quand on bouge un objet devant le capteur.
+
+:::
 
 ---
 
 ## Étape 2 : Programmer
-
-Premier programme : **lire la lumière ambiante toutes les demi-secondes et l'afficher dans la console**, en utilisant la LED RGB comme indicateur visuel (verte si lumière forte, rouge si sombre).
 
 ### Le code
 
@@ -164,36 +196,6 @@ Le programme tient en quatre éléments :
 :::info[Plage de valeurs]
 
 Le capteur retourne une valeur sur **16 bits**, donc entre **0** (obscurité totale) et **65535** (lumière très forte). En conditions normales d'éclairage de salle, on observe typiquement des valeurs de quelques dizaines à quelques milliers, il faudra peut-être ajuster `SEUIL_CLAIR` selon l'environnement. Une lampe pointée directement sur le capteur peut faire saturer la valeur à 65535.
-
-:::
-
-### Exécution
-
-- **Test rapide** : lancer le programme depuis votre IDE (typiquement bouton **Run** ▶ ou `F5`). Les valeurs défilent dans la console MicroPython.
-- **Programme persistant** : enregistrer le fichier sous le nom **`main.py`** sur la carte. Il sera relancé à chaque démarrage.
-
-### Observer les variations
-
-Une fois le programme lancé, plusieurs choses à essayer :
-
-- Couvrir le capteur avec la main : la valeur affichée chute, la LED devient rouge.
-- Approcher la carte d'une fenêtre ou d'une lampe : la valeur grimpe, la LED passe au vert.
-- Allumer la lampe d'un téléphone et la diriger vers le capteur : on voit clairement le seuil franchi.
-
-<figure style={{textAlign: 'center', margin: '1rem auto'}}>
-  <img
-    src="/img/ressources/inovmicro-exao/i04-capteur-lumiere/02-thonny-shell-mesures.png"
-    alt="Valeurs de lumière qui défilent dans la console MicroPython"
-    style={{maxWidth: '100%', height: 'auto'}}
-  />
-  <figcaption style={{fontStyle: 'italic', marginTop: '0.5rem'}}>
-    Les valeurs défilent dans la console MicroPython, et chutent quand on couvre le capteur.
-  </figcaption>
-</figure>
-
-:::info[Tracer un graphique (spécifique à Thonny)]
-
-Si vous utilisez Thonny, l'éditeur propose un **traceur de variables** : **Affichage → Plotter** (ou **View → Plotter**). Une fenêtre s'ouvre à côté de la console et trace en temps réel toutes les valeurs numériques affichées par `print()`. Pratique pour visualiser comment la lumière varie dans le temps quand on bouge un objet devant le capteur.
 
 :::
 


### PR DESCRIPTION
## Résumé

Backport des conventions adoptées dans la PR #95 (LED) vers la fiche capteur de lumière i04.

## Polish pédagogique

- **REPL** : était parachuté sans définition. Désormais expliqué inline (« Read-Eval-Print Loop, on tape une commande, elle s'exécute, on voit le résultat, la console attend la suivante »).
- **Prompt** : anglicisme remplacé par **invite** avec mention parenthétique de l'anglicisme, et description explicite du rôle du signe `>>>` (suite à un retour sur la fiche LED).
- **« C'est très différent »** étoffé pour expliciter pourquoi : `ambient_light()` donne la quantité, les canaux R/V/B donnent la **couleur dominante**.
- Ligne vide insérée entre la liste numérotée de calibrage et le paragraphe sur le pourcentage (sinon Markdown rattachait le paragraphe au point 3).

## Section « Aller plus loin »

Réorganisée en **Pour comprendre** / **Pour s'inspirer**, dans l'esprit Let's STEAM.

| Sous-section | Lien |
|---|---|
| Pour comprendre | Photorésistance (Wikipedia) — le cousin plus simple |
| Pour comprendre | Effet photoélectrique (Einstein, Nobel 1905) |
| Pour comprendre | L'œil humain — cônes/bâtonnets ↔ canal RGB |
| Pour s'inspirer | Public Lab : spectromètre DIY avec téléphone + DVD |
| Pour s'inspirer | Éclairage public adaptatif (Cerema) |
| Pour s'inspirer | Photographier la Voie Lactée en pose longue |
| Pour s'inspirer | Sextant : mesure d'angle des astres avant le GPS |

Les liens techniques retirés (driver APDS-9960, datasheet Broadcom, wiki STeaMi hardware, docs MicroPython I2C) restent accessibles via decouverte-steami pour les enseignants.

## Test plan

- [x] `npm run lint:md` passe
- [x] `npm run lint:spell` passe
- [x] `npm run lint:crosslinks` passe
- [x] `npm run site:build` passe
- [ ] Revue humaine