### PR TITLE
docs(inovmicro-exao): unifie la section "Aller plus loin" sur decouverte-steami

### DIFF
--- a/site/docs/inovmicro-exao/decouverte-steami.md
+++ b/site/docs/inovmicro-exao/decouverte-steami.md
@@ -177,9 +177,11 @@ En cas de problème (carte qui n'apparaît pas, port série introuvable, console
 
 ---
 
-## Idées de projets pour aller plus loin
+## Aller plus loin
 
-La STeaMi permet de réaliser de nombreux projets pédagogiques :
+### Pour s'inspirer
+
+La STeaMi permet de réaliser de nombreux projets pédagogiques. Quelques pistes pour amorcer une séquence :
 
 - **Station météo** : enregistrer température, humidité et pression sur plusieurs jours
 - **Altimètre** : mesurer une altitude à partir de la pression atmosphérique
@@ -189,9 +191,9 @@ La STeaMi permet de réaliser de nombreux projets pédagogiques :
 - **Jeu de réflexes** : utiliser boutons et écran pour mesurer les temps de réaction
 - **Transmission sans fil** : envoyer des données de capteur en Bluetooth vers un smartphone
 
----
+### Pour approfondir
 
-## Ressources pour approfondir
+Documentation technique pour préparer une séquence ou répondre aux questions des élèves les plus avancé·es :
 
 - **Documentation officielle** : [wiki.steami.cc](https://wiki.steami.cc/)
 - **Site STeaMi** : [steami.cc](https://steami.cc)


### PR DESCRIPTION
## Résumé

Aligne la fiche découverte sur la convention de section adoptée pour les portages I-NOVMICRO (#95/#142/#143/#144).

## Changement

Une seule section `## Aller plus loin` avec deux sous-sections :

| Avant | Après |
|---|---|
| `## Idées de projets pour aller plus loin` (7 idées) | `### Pour s'inspirer` (mêmes 7 idées) |
| `## Ressources pour approfondir` (6 liens doc) | `### Pour approfondir` (mêmes 6 liens) |

Le contenu reste identique, c'est juste une réorganisation structurelle pour la cohérence visuelle entre les fiches I-NOVMICRO. Pas de `### Pour comprendre` car le corps de la fiche EST l'apport conceptuel (présentation de la carte, capteurs, environnements de programmation).

Chaque sous-section est précédée d'une phrase d'amorce qui rappelle la cible enseignant·e :
- « Pour amorcer une séquence : »
- « Pour préparer une séquence ou répondre aux questions des élèves les plus avancé·es : »

## Test plan

- [x] `npm run lint:md`
- [x] `npm run lint:spell`
- [x] `npm run lint:crosslinks`
- [x] `npm run site:build`
- [ ] Revue humaine