### PR TITLE
docs(inovmicro-exao): intègre les apports Canva (Manon) sur t03-decouverte-thonny

### DIFF
--- a/site/docs/inovmicro-exao/t03-decouverte-thonny.md
+++ b/site/docs/inovmicro-exao/t03-decouverte-thonny.md
@@ -39,15 +39,17 @@ Programmer une carte microcontrôleur peut sembler intimidant : plusieurs logici
 
 Cette fiche met en place tout l'environnement de travail : installation de Thonny, installation de MicroPython sur la carte, configuration de la communication entre Thonny et la carte, et écriture d'un premier programme qui pilote la **LED RGB** de la STeaMi avec ses **boutons A et B**. À privilégier en salle informatique avec postes fixes ; pour des postes verrouillés ou en mobilité, préférer **Vittascience** (en ligne).
 
+Thonny n'est qu'un choix parmi d'autres : tout éditeur compatible MicroPython (Mu, VS Code, Vittascience, mpremote…) permet de programmer la STeaMi de la même façon. Cette fiche s'appuie sur Thonny pour fixer les idées, mais la démarche reste valable sur d'autres outils.
+
 ---
 
 ## Objectifs d'apprentissage
 
-- Installer Thonny et le configurer pour communiquer avec une carte MicroPython
-- Comprendre le rôle du programme MicroPython et savoir l'installer sur la STeaMi
+- Comprendre le principe de la programmation embarquée : un programme écrit sur l'ordinateur est envoyé à la carte, qui l'exécute ensuite par elle-même
+- Distinguer le rôle de l'éditeur (Thonny), du langage (MicroPython) et de la carte (STeaMi)
+- Installer Thonny et MicroPython, puis les configurer pour qu'ils dialoguent avec la STeaMi
 - Écrire et exécuter un premier programme MicroPython qui interagit avec le matériel (LED, boutons)
-- Découvrir le REPL pour tester du code en direct sans créer de fichier
-- Identifier la différence entre exécution temporaire (Run) et programme persistant (`main.py`)
+- Découvrir le REPL pour tester du code en direct sans créer de fichier, et distinguer exécution temporaire (Run) et programme persistant (`main.py`)
 ---
 
 ## Étape 1 : Construire
@@ -117,9 +119,9 @@ Si le disque `STEAMI` n'apparaît pas, le premier réflexe est de changer de câ
 Si Thonny démarre en anglais : **Tools → Options → onglet General → Language: Français**, puis redémarrer Thonny. La suite utilise les libellés français.
 
 1. Ouvrir Thonny.
-2. **Outils → Options… → onglet Interpréteur**.
+2. **Outils → Options… → onglet Interpréteur** (le terme employé par Thonny pour désigner l'appareil sur lequel le code va s'exécuter).
 3. Liste **Quel interpréteur ou appareil utiliser** : choisir **MicroPython (generic)**.
-4. **Port** : sélectionner celui de la STeaMi.
+4. **Port** (la prise par laquelle l'ordinateur dialogue avec la carte) : sélectionner celui de la STeaMi.
    - Linux : `/dev/ttyACM0`
    - macOS : `/dev/cu.usbmodemXXXX`
    - Windows : `COM3`, `COM4`…
@@ -227,6 +229,12 @@ while True:
 
     sleep_ms(20)
 ```
+
+### Fonctionnement du programme
+
+- **Préparation des composants.** Les premières lignes donnent un nom à chaque élément et précisent comment on l'utilise. `Pin('LED_RED', Pin.OUT)` déclare la LED rouge en **sortie** (la carte lui envoie une valeur pour l'allumer ou l'éteindre), tandis que `Pin('A_BUTTON', Pin.IN)` déclare le bouton A en **entrée** (la carte lit sa valeur). On répète l'opération pour les trois LED et les deux boutons.
+- **La fonction `set_rgb`.** Plutôt que de réécrire trois lignes à chaque fois, on regroupe l'allumage des trois LED dans une petite fonction : `set_rgb(1, 0, 0)` allume le rouge et éteint les deux autres.
+- **La boucle.** `while True` répète sans fin. À chaque tour, le programme lit l'état des deux boutons, allume la couleur correspondante, puis fait une courte pause `sleep_ms(20)`. La boucle tourne ainsi environ 50 fois par seconde : assez vite pour que la réponse paraisse instantanée, assez doucement pour ne pas surcharger la carte.
 
 ### Exécution
 


### PR DESCRIPTION
## Résumé

Intègre les apports pédagogiques de la version Canva de Manon (`STeaMi_Thonny`, [lien](https://canva.link/houlsiq5i316qqt)) dans la fiche [`t03-decouverte-thonny.md`](https://github.com/LabAixBidouille/wikilab/blob/content/inovmicro-thonny-apports-canva-manon/site/docs/inovmicro-exao/t03-decouverte-thonny.md) :

- **Ajoute la section « Fonctionnement du programme »** dans l'Étape 2 (apport principal) qui décortique le code en trois temps : préparation des composants (entrée/sortie), rôle de la fonction `set_rgb`, et fonctionnement de la boucle `while True` avec `sleep_ms(20)`.
- **Précise que Thonny n'est qu'un choix parmi d'autres** dans « De quoi parle-t-on » (Mu, VS Code, Vittascience, mpremote sont mentionnés comme alternatives compatibles MicroPython).
- **Intercale des définitions « Interpréteur » et « Port »** dans la procédure de configuration de Thonny.
- **Reformule les objectifs d'apprentissage** : ajoute deux objectifs conceptuels (principe de la programmation embarquée, distinction éditeur/langage/carte) tout en conservant les objectifs opérationnels existants.

## Non repris depuis Canva (volontairement)

- Footer crédits AMI France 2030 (décision : pas ici).
- Suppressions du débogueur pas-à-pas, du tableau Brochage, des aides `:::info[Identifier le bon port]`, du tableau de raccourcis REPL et des exemples I2C : on les conserve, c'est de la doc utile.
- Aplatissement de « Aller plus loin » : on garde la structure « Pour s'inspirer / Pour approfondir » (convention LS).
- Remplacement de « REPL » par « console » : on garde « REPL » (convention LS).

## Type de changement

- [x] Contenu — fiche, doc, texte
- [ ] Catalogue — entrée(s) dans `resources.ts` ou `projects.ts`
- [ ] Code — composant React, page, type, CSS
- [ ] Configuration — config Docusaurus, CI, hooks
- [ ] Assets — images, PDFs, vidéos

## Test plan

- [x] `npm run site:build` passe sans erreur ni nouveau warning
- [x] `npm run site:typecheck` passe
- [x] Lint OK : `npm run format:check && npm run lint:md && npm run lint:spell` (cspell sur le fichier modifié : 0 issue)
- [ ] Vérification visuelle locale dans le navigateur
- [x] Conforme aux conventions de [`CLAUDE.md`](../CLAUDE.md) et à la mémoire « Conformité Let's STEAM pour fiches I-NOVMICRO portées » (REPL conservé, structure « Pour s'inspirer / Pour approfondir » conservée).

## Issues liées

Closes #148