### PR TITLE
docs(inovmicro-exao): retire les caractères non ASCII des fiches mergées

### DIFF
--- a/site/docs/inovmicro-exao/depannage.md
+++ b/site/docs/inovmicro-exao/depannage.md
@@ -51,11 +51,11 @@ Plusieurs ports `COM` (Windows) ou `/dev/cu.usbmodem*` (macOS) peuvent apparaît
 
 ### Windows
 
-Ouvrir le **Gestionnaire de périphériques** (Windows + R → `devmgmt.msc`), dérouler **Ports (COM et LPT)**. Brancher puis débrancher la carte fait apparaître / disparaître l'entrée correspondante. Le numéro `COMx` affiché à côté est celui à choisir dans votre IDE.
+Ouvrir le **Gestionnaire de périphériques** (Windows + R, puis `devmgmt.msc`), dérouler **Ports (COM et LPT)**. Brancher puis débrancher la carte fait apparaître / disparaître l'entrée correspondante. Le numéro `COMx` affiché à côté est celui à choisir dans votre IDE.
 
 ### Linux
 
-Sur la plupart des distributions, la STeaMi apparaît comme `/dev/ttyACM0` (ou `ACM1`, etc. si plusieurs cartes série sont déjà branchées). Si l'accès au port est refusé avec une erreur **`Permission denied`** (en anglais : « permission refusée »), c'est que l'utilisateur·rice n'est pas dans le groupe `dialout` — un groupe Linux qui rassemble les comptes autorisés à communiquer avec les ports série. Une fois pour toutes :
+Sur la plupart des distributions, la STeaMi apparaît comme `/dev/ttyACM0` (ou `ACM1`, etc. si plusieurs cartes série sont déjà branchées). Si l'accès au port est refusé avec une erreur **`Permission denied`** (en anglais : « permission refusée »), c'est que l'utilisateur·rice n'est pas dans le groupe `dialout`, un groupe Linux qui rassemble les comptes autorisés à communiquer avec les ports série. Une fois pour toutes :
 
 ```bash
 sudo usermod -aG dialout $USER
@@ -71,7 +71,7 @@ Le port apparaît sous la forme `/dev/cu.usbmodemXXXX` (le suffixe est généré
 
 ## MicroPython pas installé
 
-**Symptôme** : la carte apparaît bien (disque `STEAMI` visible, port série détecté), mais la console de l'IDE reste vide ou affiche un message d'erreur au lieu de `>>>` — c'est **l'invite** (parfois appelée « prompt » en anglais) : un signe qui apparaît en début de ligne pour vous dire que la console est prête à recevoir une commande.
+**Symptôme** : la carte apparaît bien (disque `STEAMI` visible, port série détecté), mais la console de l'IDE reste vide ou affiche un message d'erreur au lieu de `>>>`. C'est **l'invite** (parfois appelée « prompt » en anglais) : un signe qui apparaît en début de ligne pour vous dire que la console est prête à recevoir une commande.
 
 **Cause** : la carte a peut-être un autre logiciel installé en interne (MakeCode, CODAL, ou rien) au lieu de MicroPython.
 
@@ -97,9 +97,9 @@ Le dépôt GitHub `micropython-steami-lib` propose aussi un fichier `steami-dapl
 
 **Solution** : sélectionner explicitement le port dans la configuration de l'IDE.
 
-- **Thonny** : `Outils → Options → onglet Interpréteur → Port`, puis choisir le bon port dans la liste.
-- **Mu** : la sélection se fait automatiquement, mais on peut forcer via `Préférences → Mode → MicroPython (generic)`.
-- **VS Code** + extension MicroPython : `Ctrl+Shift+P` → `MicroPython: Select Device`.
+- **Thonny** : `Outils > Options > onglet Interpréteur > Port`, puis choisir le bon port dans la liste.
+- **Mu** : la sélection se fait automatiquement, mais on peut forcer via `Préférences > Mode > MicroPython (generic)`.
+- **VS Code** + extension MicroPython : `Ctrl+Shift+P` puis `MicroPython: Select Device`.
 - **`mpremote`** : ajouter `connect <port>` à la commande, par exemple `mpremote connect /dev/ttyACM1 repl`.
 
 Pour identifier le port à choisir, voir [Identifier le bon port série](#identifier-le-bon-port-série).

--- a/site/docs/inovmicro-exao/i01-led.md
+++ b/site/docs/inovmicro-exao/i01-led.md
@@ -25,7 +25,7 @@ sidebar_position: 8
 - 1 carte STeaMi
 - 1 câble USB de données (micro-USB pour la STeaMi V1, USB-C pour la STeaMi V2).
 - 1 ordinateur sous Windows, macOS ou Linux
-- Un IDE compatible MicroPython : Thonny (voir la fiche [Thonny : Prise en main de MicroPython](/ressources/inovmicro-exao/t03-decouverte-thonny)) ou tout autre éditeur compatible (Mu, VS Code, Vittascience, `mpremote`…).
+- Un IDE compatible MicroPython : Thonny (voir la fiche [Thonny : Prise en main de MicroPython](/ressources/inovmicro-exao/t03-decouverte-thonny)) ou tout autre éditeur compatible (Mu, VS Code, Vittascience, `mpremote`...).
 
 </div>
 <img src="/img/ressources/inovmicro-exao/i01-led/icone.png" alt="Faire clignoter une LED" style={{width: '225px', height: '225px', objectFit: 'contain', flexShrink: 0}} />
@@ -35,7 +35,7 @@ sidebar_position: 8
 
 ## De quoi parle-t-on ?
 
-La **LED** (light-emitting diode) est un composant électronique qui produit de la lumière lorsqu'un courant la traverse. On la retrouve partout dans le quotidien : pour éclairer, pour signaler un état (réservoir presque vide, machine allumée…), ou simplement comme indicateur visuel.
+La **LED** (light-emitting diode) est un composant électronique qui produit de la lumière lorsqu'un courant la traverse. On la retrouve partout dans le quotidien : pour éclairer, pour signaler un état (réservoir presque vide, machine allumée, etc.), ou simplement comme indicateur visuel.
 
 La STeaMi intègre une LED RGB, accessibles sans aucun câblage, avec trois couleurs : **rouge**, **verte** et **bleue**. C'est le point de départ idéal pour comprendre comment un programme contrôle un composant physique : **allumer, éteindre, attendre, recommencer**. Le programme que vous allez écrire est le premier programme qu'on écrit quand on découvre l'électronique embarquée (les informaticiens appellent ça un « Hello World »).
 
@@ -110,7 +110,7 @@ while True:
 
 - `from machine import Pin` importe l'objet `Pin` du module `machine`, qui permet de piloter les broches du microcontrôleur.
 - `from time import sleep_ms` importe la fonction `sleep_ms`, qui suspend l'exécution du programme pendant un nombre de millisecondes donné.
-- `Pin('LED_BLUE', Pin.OUT)` crée un objet qui représente la LED bleue, configurée en **sortie** (la broche envoie un signal, elle ne le lit pas). Le firmware STeaMi expose les composants intégrés sous des noms parlants — pas besoin de mémoriser un numéro de broche.
+- `Pin('LED_BLUE', Pin.OUT)` crée un objet qui représente la LED bleue, configurée en **sortie** (la broche envoie un signal, elle ne le lit pas). Le firmware STeaMi expose les composants intégrés sous des noms parlants. Pas besoin de mémoriser un numéro de broche.
 - La variable `delay` fixe la durée de chaque état (allumée ou éteinte) à 500 millisecondes. Modifier cette valeur change directement la vitesse de clignotement.
 - La boucle `while True:` s'exécute indéfiniment : elle allume la LED, attend `delay` ms, éteint la LED, attend encore `delay` ms, et recommence.
 
@@ -139,17 +139,17 @@ Une fois le clignotement maîtrisé, une bonne piste pour aller plus loin est de
 
 ### Pour comprendre
 
-- **[Diode électroluminescente — Wikipedia](https://fr.wikipedia.org/wiki/Diode_%C3%A9lectroluminescente)** : histoire des LED, principes physiques qui les sous-tendent, typologies et couleurs.
-- **[Courant et tension — bases de l'électricité](https://www.codrey.com/dc-circuits/current-and-voltage/)** : tutoriel à destination des débutants en électronique pour explorer le courant, la tension, leur différence et leur fonctionnement (en anglais).
+- **[Diode électroluminescente (Wikipedia)](https://fr.wikipedia.org/wiki/Diode_%C3%A9lectroluminescente)** : histoire des LED, principes physiques qui les sous-tendent, typologies et couleurs.
+- **[Courant et tension, bases de l'électricité](https://www.codrey.com/dc-circuits/current-and-voltage/)** : tutoriel à destination des débutants en électronique pour explorer le courant, la tension, leur différence et leur fonctionnement (en anglais).
 - **[Shuji Nakamura, l'inventeur de la LED bleue](https://fr.wikipedia.org/wiki/Shuji_Nakamura)** : prix Nobel de physique 2014. Sans sa LED bleue (résultat de 25 ans de recherche), pas d'éclairage LED blanc, pas d'écrans pleine couleur. Une belle histoire de persévérance face à des décennies d'échecs annoncés.
 
 ### Pour s'inspirer
 
-- **[Fête des Lumières de Lyon](https://fr.wikipedia.org/wiki/F%C3%AAte_des_lumi%C3%A8res)** : 4 jours par an, la ville devient une scène d'installations lumineuses pilotées par des programmes — un exemple à grande échelle de ce qu'un peu de code et beaucoup de LED peuvent produire.
-- **[The Bay Lights — Leo Villareal](https://en.wikipedia.org/wiki/The_Bay_Lights)** : 25 000 LED disposées sur le Bay Bridge de San Francisco, animées par un programme génératif qui ne se répète jamais. Une œuvre d'art urbain visible à des kilomètres.
-- **[Faire un cube LED de A à Z](https://www.youtube.com/watch?v=ciaFar8nfHc)** (GreatScott!, en anglais) : le grand classique maker — 64 ou 512 LED soudées en 3D, multiplexage temporel pour les piloter avec quelques broches seulement, animations volumétriques.
-- **[Word Clock — l'horloge à mots](https://www.instructables.com/The-Word-Clock-Arduino-version/)** : une grille de LED qui éclaire des lettres pour écrire l'heure en toutes lettres (« IL EST DIX HEURES VINGT »). Petit projet de programmation + design plein de charme.
-- **[Adafruit NeoPixel Überguide](https://learn.adafruit.com/adafruit-neopixel-uberguide)** : les LED RGB adressables WS2812 — un bus de données, des centaines de LED en chaîne, des effets arc-en-ciel et des bandeaux décoratifs à l'infini. La suite logique quand une seule LED ne suffit plus.
+- **[Fête des Lumières de Lyon](https://fr.wikipedia.org/wiki/F%C3%AAte_des_lumi%C3%A8res)** : 4 jours par an, la ville devient une scène d'installations lumineuses pilotées par des programmes, un exemple à grande échelle de ce qu'un peu de code et beaucoup de LED peuvent produire.
+- **[The Bay Lights de Leo Villareal](https://en.wikipedia.org/wiki/The_Bay_Lights)** : 25 000 LED disposées sur le Bay Bridge de San Francisco, animées par un programme génératif qui ne se répète jamais. Une œuvre d'art urbain visible à des kilomètres.
+- **[Faire un cube LED de A à Z](https://www.youtube.com/watch?v=ciaFar8nfHc)** (GreatScott!, en anglais) : le grand classique maker, 64 ou 512 LED soudées en 3D, multiplexage temporel pour les piloter avec quelques broches seulement, animations volumétriques.
+- **[Word Clock, l'horloge à mots](https://www.instructables.com/The-Word-Clock-Arduino-version/)** : une grille de LED qui éclaire des lettres pour écrire l'heure en toutes lettres (« IL EST DIX HEURES VINGT »). Petit projet de programmation + design plein de charme.
+- **[Adafruit NeoPixel Überguide](https://learn.adafruit.com/adafruit-neopixel-uberguide)** : les LED RGB adressables WS2812, un bus de données, des centaines de LED en chaîne, des effets arc-en-ciel et des bandeaux décoratifs à l'infini. La suite logique quand une seule LED ne suffit plus.
 
 ---
 

--- a/site/docs/inovmicro-exao/i04-capteur-lumiere.md
+++ b/site/docs/inovmicro-exao/i04-capteur-lumiere.md
@@ -24,9 +24,9 @@ sidebar_position: 11
 ## Matériel et Montage
 
 - 1 carte STeaMi
-- 1 câble USB de données (micro-USB pour la STeaMi V1, USB-C pour la STeaMi V2). Attention : un câble qui ne sert qu'à charger un téléphone ne fonctionnera pas.
+- 1 câble USB de données (micro-USB pour la STeaMi V1, USB-C pour la STeaMi V2).
 - 1 ordinateur sous Windows, macOS ou Linux
-- Un IDE MicroPython installé et configuré pour la STeaMi. Voir la fiche [Thonny : Prise en main de MicroPython](/ressources/inovmicro-exao/t03-decouverte-thonny) pour la mise en place, tout autre éditeur compatible MicroPython (Mu, VS Code, Vittascience, `mpremote`…) fonctionne aussi.
+- Un IDE MicroPython installé et configuré pour la STeaMi. Voir la fiche [Thonny : Prise en main de MicroPython](/ressources/inovmicro-exao/t03-decouverte-thonny) pour la mise en place, tout autre éditeur compatible MicroPython (Mu, VS Code, Vittascience, `mpremote`...) fonctionne aussi.
 </div>
 <img src="/img/ressources/inovmicro-exao/i04-capteur-lumiere/icone.png" alt="Capteur de lumière sur la STeaMi" style={{width: '225px', height: '225px', objectFit: 'contain', flexShrink: 0}} />
 </div>
@@ -80,7 +80,7 @@ Contrairement à une photorésistance qui fournit une tension variable lue par u
 
 ### 2. Connecter la carte à l'ordinateur
 
-Brancher la STeaMi à l'ordinateur via le câble USB. Si votre IDE MicroPython est déjà configuré (voir la fiche [Thonny : Prise en main de MicroPython](/ressources/inovmicro-exao/t03-decouverte-thonny) si vous démarrez), la console MicroPython doit afficher `>>>` — c'est **l'invite** (parfois appelée « prompt » en anglais) : un signe qui apparaît en début de ligne pour vous dire que la console est prête à recevoir une commande.
+Brancher la STeaMi à l'ordinateur via le câble USB. Si votre IDE MicroPython est déjà configuré (voir la fiche [Thonny : Prise en main de MicroPython](/ressources/inovmicro-exao/t03-decouverte-thonny) si vous démarrez), la console MicroPython doit afficher `>>>`. C'est **l'invite** (parfois appelée « prompt » en anglais) : un signe qui apparaît en début de ligne pour vous dire que la console est prête à recevoir une commande.
 
 ### 3. Vérifier que le capteur répond
 
@@ -97,7 +97,7 @@ L'adresse `0x39` correspond à l'APDS-9960. Si elle apparaît, le capteur répon
 
 ### 4. Lancer le programme
 
-Notre premier programme va **lire la lumière ambiante toutes les demi-secondes et l'afficher dans la console**, en utilisant la LED RGB comme indicateur visuel (verte si lumière forte, rouge si sombre). Le code complet est donné à l'[Étape 2 : Programmer](#étape-2--programmer) ci-dessous — copiez-le dans votre IDE.
+Notre premier programme va **lire la lumière ambiante toutes les demi-secondes et l'afficher dans la console**, en utilisant la LED RGB comme indicateur visuel (verte si lumière forte, rouge si sombre). Le code complet est donné à l'[Étape 2 : Programmer](#étape-2--programmer) ci-dessous. Copiez-le dans votre IDE.
 
 Une fois le code en place, deux manières de le lancer :
 
@@ -125,7 +125,7 @@ Une fois le programme lancé, plusieurs choses à essayer :
 
 :::info[Tracer un graphique (spécifique à Thonny)]
 
-Si vous utilisez Thonny, l'éditeur propose un **traceur de variables** : **Affichage → Plotter** (ou **View → Plotter**). Une fenêtre s'ouvre à côté de la console et trace en temps réel toutes les valeurs numériques affichées par `print()`. Pratique pour visualiser comment la lumière varie dans le temps quand on bouge un objet devant le capteur.
+Si vous utilisez Thonny, l'éditeur propose un **traceur de variables** : **Affichage > Plotter** (ou **View > Plotter** en anglais). Une fenêtre s'ouvre à côté de la console et trace en temps réel toutes les valeurs numériques affichées par `print()`. Pratique pour visualiser comment la lumière varie dans le temps quand on bouge un objet devant le capteur.
 
 :::
 
@@ -252,15 +252,15 @@ else:
 
 ### Pour comprendre
 
-- **[Photorésistance — Wikipedia](https://fr.wikipedia.org/wiki/Photor%C3%A9sistance)** : le composant cousin de l'APDS-9960. Plus simple : sa résistance change avec la lumière, et c'est tout. Beaucoup de capteurs de lumière débutants en utilisent.
-- **[Effet photoélectrique — Wikipedia](https://fr.wikipedia.org/wiki/Effet_photo%C3%A9lectrique)** : pourquoi la lumière fait du courant. C'est l'explication publiée par Einstein en 1905 qui lui a valu le prix Nobel de physique en 1921 — pas la relativité comme on le croit souvent.
-- **[L'œil humain — Wikipedia](https://fr.wikipedia.org/wiki/%C5%92il_humain)** : votre œil est un capteur de lumière biologique avec deux types de cellules (cônes pour la couleur, bâtonnets pour la nuit). C'est exactement le principe d'un capteur RGB comme l'APDS-9960, mais en chair et en os.
+- **[Photorésistance (Wikipedia)](https://fr.wikipedia.org/wiki/Photor%C3%A9sistance)** : le composant cousin de l'APDS-9960. Plus simple : sa résistance change avec la lumière, et c'est tout. Beaucoup de capteurs de lumière débutants en utilisent.
+- **[Effet photoélectrique (Wikipedia)](https://fr.wikipedia.org/wiki/Effet_photo%C3%A9lectrique)** : pourquoi la lumière fait du courant. C'est l'explication publiée par Einstein en 1905 qui lui a valu le prix Nobel de physique en 1921, pas la relativité comme on le croit souvent.
+- **[L'œil humain (Wikipedia)](https://fr.wikipedia.org/wiki/%C5%92il_humain)** : votre œil est un capteur de lumière biologique avec deux types de cellules (cônes pour la couleur, bâtonnets pour la nuit). C'est exactement le principe d'un capteur RGB comme l'APDS-9960, mais en chair et en os.
 
 ### Pour s'inspirer
 
-- **[Public Lab — DIY spectromètre](https://publiclab.org/wiki/spectrometry)** : une communauté de scientifiques amateurs qui ont construit un spectromètre à partir d'un téléphone et d'un DVD. Sert à analyser la pollution de l'eau, identifier des matériaux, ou étudier la chlorophylle des plantes.
+- **[Public Lab, DIY spectromètre](https://publiclab.org/wiki/spectrometry)** : une communauté de scientifiques amateurs qui ont construit un spectromètre à partir d'un téléphone et d'un DVD. Sert à analyser la pollution de l'eau, identifier des matériaux, ou étudier la chlorophylle des plantes.
 - **[Éclairage public adaptatif (Cerema)](https://www.cerema.fr/fr/actualites/eclairage-public-adaptation-eclairage-presence)** : éteindre ou réduire les lampadaires quand la rue est vide, c'est exactement ce qu'on fait dans cette fiche, mais à l'échelle d'une ville. Économies d'énergie + moins de pollution lumineuse.
-- **[Photographier la Voie Lactée](https://www.lemonde.fr/blog/autourduciel/2020/05/22/photographier-la-voie-lactee-en-pause-longue/)** : avec des poses de plusieurs secondes ou minutes, un capteur photo accumule la lumière la plus faible — c'est comme cela que les astronomes amateurs photographient des galaxies invisibles à l'œil nu.
-- **[Sextant — Wikipedia](https://fr.wikipedia.org/wiki/Sextant)** : avant le GPS, les marins se repéraient en mesurant l'angle entre un astre et l'horizon. Une histoire fascinante d'instruments de mesure et de navigation.
+- **[Photographier la Voie Lactée](https://www.lemonde.fr/blog/autourduciel/2020/05/22/photographier-la-voie-lactee-en-pause-longue/)** : avec des poses de plusieurs secondes ou minutes, un capteur photo accumule la lumière la plus faible. C'est comme cela que les astronomes amateurs photographient des galaxies invisibles à l'œil nu.
+- **[Sextant (Wikipedia)](https://fr.wikipedia.org/wiki/Sextant)** : avant le GPS, les marins se repéraient en mesurant l'angle entre un astre et l'horizon. Une histoire fascinante d'instruments de mesure et de navigation.
 
 _Cette fiche fait partie du projet [I-Novmicro #2 : Action EXAO](/projets/inovmicro-exao). Adaptée du projet [Let's STEAM](/projets/lets-steam) (fiche [`r1as04-capteur-lumiere`](/ressources/lets-steam/r1as04-capteur-lumiere)) sous licence [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/deed.fr)._

--- a/site/docs/inovmicro-exao/i06-code-morse.md
+++ b/site/docs/inovmicro-exao/i06-code-morse.md
@@ -23,9 +23,9 @@ sidebar_position: 13
 ## Matériel et Montage
 
 - 1 carte STeaMi
-- 1 câble USB de données (micro-USB pour la STeaMi V1, USB-C pour la STeaMi V2). Attention : un câble qui ne sert qu'à charger un téléphone ne fonctionnera pas.
+- 1 câble USB de données (micro-USB pour la STeaMi V1, USB-C pour la STeaMi V2).
 - 1 ordinateur sous Windows, macOS ou Linux
-- Un IDE compatible MicroPython : Thonny (voir la fiche [Thonny : Prise en main de MicroPython](/ressources/inovmicro-exao/t03-decouverte-thonny)) ou tout autre éditeur compatible (Mu, VS Code, Vittascience, `mpremote`…).
+- Un IDE compatible MicroPython : Thonny (voir la fiche [Thonny : Prise en main de MicroPython](/ressources/inovmicro-exao/t03-decouverte-thonny)) ou tout autre éditeur compatible (Mu, VS Code, Vittascience, `mpremote`...).
 
 </div>
 <img src="/img/ressources/inovmicro-exao/i06-code-morse/icone.png" alt="Code Morse sur la STeaMi" style={{width: '225px', height: '225px', objectFit: 'contain', flexShrink: 0}} />
@@ -100,7 +100,7 @@ Deux remarques sur cet extrait :
 
 ### 2. Connecter la carte à l'ordinateur
 
-Brancher la STeaMi à l'ordinateur via le câble USB. Si l'IDE est déjà configuré, la console MicroPython doit afficher `>>>` — c'est **l'invite** (parfois appelée « prompt » en anglais) : un signe qui apparaît en début de ligne pour vous dire que la console est prête à recevoir une commande.
+Brancher la STeaMi à l'ordinateur via le câble USB. Si l'IDE est déjà configuré, la console MicroPython doit afficher `>>>`. C'est **l'invite** (parfois appelée « prompt » en anglais) : un signe qui apparaît en début de ligne pour vous dire que la console est prête à recevoir une commande.
 
 ### 3. Tester le buzzer dans le REPL
 
@@ -122,7 +122,7 @@ Le buzzer émet la note La pendant une demi-seconde. Ce code marche, mais il est
 
 ### 4. Lancer le programme
 
-Notre premier programme va **émettre des points et des tirets selon le bouton appuyé** : bouton A → signal court (point, 100 ms), bouton B → signal long (tiret, 300 ms). Le code complet est donné à l'[Étape 2 : Programmer](#etape-2--programmer) ci-dessous — copiez-le dans votre IDE.
+Notre premier programme va **émettre des points et des tirets selon le bouton appuyé** : le bouton A produit un signal court (point, 100 ms), le bouton B produit un signal long (tiret, 300 ms). Le code complet est donné à l'[Étape 2 : Programmer](#etape-2--programmer) ci-dessous. Copiez-le dans votre IDE.
 
 Une fois le code en place, deux manières de le lancer :
 
@@ -322,17 +322,17 @@ C'est un excellent exercice pour découvrir les **structures de données** (dict
 
 ### Pour comprendre
 
-- **[Code Morse international — Wikipedia](https://fr.wikipedia.org/wiki/Code_Morse_international)** : histoire, table complète, règles de timing détaillées.
-- **[Effet piézoélectrique — Wikipedia](https://fr.wikipedia.org/wiki/Effet_pi%C3%A9zo%C3%A9lectrique)** : pourquoi un cristal de céramique se déforme quand on lui applique une tension. Le principe derrière les buzzers, les briquets électriques, les microphones de guitare et les capteurs de pression.
-- **[Samuel Morse — Wikipedia](https://fr.wikipedia.org/wiki/Samuel_Morse)** : peintre américain reconnu, il invente le télégraphe après avoir appris trop tard la mort de sa femme. Une bascule de carrière qui révolutionnera les communications.
-- **[Théorie de l'information — Wikipedia](https://fr.wikipedia.org/wiki/Th%C3%A9orie_de_l%27information)** : le code Morse est le premier exemple historique de **codage à longueur variable** (les lettres fréquentes sont les plus courtes). Cette intuition a inspiré le codage de Huffman et toute la compression de données moderne (zip, JPEG, MP3…).
+- **[Code Morse international (Wikipedia)](https://fr.wikipedia.org/wiki/Code_Morse_international)** : histoire, table complète, règles de timing détaillées.
+- **[Effet piézoélectrique (Wikipedia)](https://fr.wikipedia.org/wiki/Effet_pi%C3%A9zo%C3%A9lectrique)** : pourquoi un cristal de céramique se déforme quand on lui applique une tension. Le principe derrière les buzzers, les briquets électriques, les microphones de guitare et les capteurs de pression.
+- **[Samuel Morse (Wikipedia)](https://fr.wikipedia.org/wiki/Samuel_Morse)** : peintre américain reconnu, il invente le télégraphe après avoir appris trop tard la mort de sa femme. Une bascule de carrière qui révolutionnera les communications.
+- **[Théorie de l'information (Wikipedia)](https://fr.wikipedia.org/wiki/Th%C3%A9orie_de_l%27information)** : le code Morse est le premier exemple historique de **codage à longueur variable** (les lettres fréquentes sont les plus courtes). Cette intuition a inspiré le codage de Huffman et toute la compression de données moderne (zip, JPEG, MP3...).
 
 ### Pour s'inspirer
 
-- **[Les « messages personnels » de Radio Londres](https://fr.wikipedia.org/wiki/Messages_personnels)** : pendant la Seconde Guerre mondiale, la BBC ouvrait ses émissions vers la France par les premières notes de la 5ᵉ symphonie de Beethoven — qui sont exactement la lettre **V** en code Morse (`. . . -`), pour _Victoire_. Suivaient des phrases codées destinées à la Résistance.
+- **[Les « messages personnels » de Radio Londres](https://fr.wikipedia.org/wiki/Messages_personnels)** : pendant la Seconde Guerre mondiale, la BBC ouvrait ses émissions vers la France par les premières notes de la 5ᵉ symphonie de Beethoven, qui sont exactement la lettre **V** en code Morse (`. . . -`), pour _Victoire_. Suivaient des phrases codées destinées à la Résistance.
 - **[SOS, le signal de détresse universel](https://fr.wikipedia.org/wiki/SOS)** : adopté en 1908 pour sa simplicité en Morse (`. . . - - - . . .`), c'est l'un des premiers signaux radio à avoir traversé les océans. Le Titanic l'a utilisé en 1912, contribuant à imposer son usage international.
 - **[Radioamateurisme](https://fr.wikipedia.org/wiki/Radioamateur)** : un hobby mondial qui continue d'organiser des concours de transmission en Morse à très longue distance, parfois avec très peu d'énergie. Une communauté active de bidouilleurs d'ondes.
-- **[Chiptune — Wikipedia](https://fr.wikipedia.org/wiki/Chiptune)** : style musical né dans les années 80 qui exploite les puces audio limitées des consoles 8 bits — la STeaMi fait exactement ce qu'une Game Boy faisait pour produire ses musiques.
+- **[Chiptune (Wikipedia)](https://fr.wikipedia.org/wiki/Chiptune)** : style musical né dans les années 80 qui exploite les puces audio limitées des consoles 8 bits. La STeaMi fait exactement ce qu'une Game Boy faisait pour produire ses musiques.
 
 ---
 

--- a/site/docs/inovmicro-exao/i06-code-morse.md
+++ b/site/docs/inovmicro-exao/i06-code-morse.md
@@ -118,11 +118,11 @@ Avant d'écrire le programme principal, on peut vérifier que le buzzer répond 
 ...     time.sleep_us(1136)
 ```
 
-Le buzzer émet la note La pendant une demi-seconde. Ce code marche, mais il est laborieux : on va l'emballer dans une fonction `tone()` réutilisable dans le programme de l'[Étape 2 : Programmer](#etape-2--programmer) ci-dessous.
+Le buzzer émet la note La pendant une demi-seconde. Ce code marche, mais il est laborieux : on va l'emballer dans une fonction `tone()` réutilisable dans le programme de l'[Étape 2 : Programmer](#étape-2--programmer) ci-dessous.
 
 ### 4. Lancer le programme
 
-Notre premier programme va **émettre des points et des tirets selon le bouton appuyé** : le bouton A produit un signal court (point, 100 ms), le bouton B produit un signal long (tiret, 300 ms). Le code complet est donné à l'[Étape 2 : Programmer](#etape-2--programmer) ci-dessous. Copiez-le dans votre IDE.
+Notre premier programme va **émettre des points et des tirets selon le bouton appuyé** : le bouton A produit un signal court (point, 100 ms), le bouton B produit un signal long (tiret, 300 ms). Le code complet est donné à l'[Étape 2 : Programmer](#étape-2--programmer) ci-dessous. Copiez-le dans votre IDE.
 
 Une fois le code en place, deux manières de le lancer :
 

--- a/site/docs/inovmicro-exao/i10-texte-oled.md
+++ b/site/docs/inovmicro-exao/i10-texte-oled.md
@@ -23,9 +23,9 @@ sidebar_position: 17
 ## Matériel et Montage
 
 - 1 carte STeaMi
-- 1 câble USB de données (micro-USB pour la STeaMi V1, USB-C pour la STeaMi V2). Attention : un câble qui ne sert qu'à charger un téléphone ne fonctionnera pas.
+- 1 câble USB de données (micro-USB pour la STeaMi V1, USB-C pour la STeaMi V2).
 - 1 ordinateur sous Windows, macOS ou Linux
-- Un IDE compatible MicroPython : Thonny (voir la fiche [Thonny : Prise en main de MicroPython](/ressources/inovmicro-exao/t03-decouverte-thonny)) ou tout autre éditeur compatible (Mu, VS Code, Vittascience, `mpremote`…).
+- Un IDE compatible MicroPython : Thonny (voir la fiche [Thonny : Prise en main de MicroPython](/ressources/inovmicro-exao/t03-decouverte-thonny)) ou tout autre éditeur compatible (Mu, VS Code, Vittascience, `mpremote`...).
 
 </div>
 <img src="/img/ressources/inovmicro-exao/i10-texte-oled/icone.png" alt="Écran OLED de la STeaMi affichant du texte" style={{width: '225px', height: '225px', objectFit: 'contain', flexShrink: 0}} />
@@ -44,7 +44,7 @@ Cette fiche met en pratique l'affichage de texte sur l'écran OLED 128×128 de l
 ## Objectifs d'apprentissage
 
 - Comprendre comment l'écran s'actualise (notion de **framebuffer**)
-- Composer un affichage à l'écran en plaçant texte et symboles aux **points cardinaux** (`N`, `S`, `CENTER`…) ou à des coordonnées précises
+- Composer un affichage à l'écran en plaçant texte et symboles aux **points cardinaux** (`N`, `S`, `CENTER`, etc.) ou à des coordonnées précises
 - Hiérarchiser l'information affichée avec les raccourcis `screen.title()` et `screen.subtitle()`
 - Faire vivre l'écran au rythme du programme pour suivre l'état d'une variable
 
@@ -56,7 +56,7 @@ Sur la STeaMi, l'écran est déjà câblé en interne, il n'y a aucun montage ex
 
 ### 1. Connecter la carte à l'ordinateur
 
-Brancher la STeaMi avec son câble USB (micro-USB sur la STeaMi V1, USB-C sur la STeaMi V2). Un nouveau lecteur appelé `STEAMI` apparaît sur l'ordinateur. Si l'IDE est déjà configuré (voir la fiche [Thonny : Prise en main de MicroPython](/ressources/inovmicro-exao/t03-decouverte-thonny) si vous démarrez), la console MicroPython doit afficher `>>>` — c'est **l'invite** (parfois appelée « prompt » en anglais) : un signe qui apparaît en début de ligne pour vous dire que la console est prête à recevoir une commande.
+Brancher la STeaMi avec son câble USB (micro-USB sur la STeaMi V1, USB-C sur la STeaMi V2). Un nouveau lecteur appelé `STEAMI` apparaît sur l'ordinateur. Si l'IDE est déjà configuré (voir la fiche [Thonny : Prise en main de MicroPython](/ressources/inovmicro-exao/t03-decouverte-thonny) si vous démarrez), la console MicroPython doit afficher `>>>`. C'est **l'invite** (parfois appelée « prompt » en anglais) : un signe qui apparaît en début de ligne pour vous dire que la console est prête à recevoir une commande.
 
 <figure style={{textAlign: 'center', margin: '1rem auto'}}>
   <img
@@ -123,7 +123,7 @@ Avec `at="N"`, le texte est aligné en haut et centré horizontalement ; avec `a
 
 ### 4. Lancer le programme
 
-Le programme principal est donné à l'[Étape 2 : Programmer](#étape-2--programmer) ci-dessous — copiez-le dans votre IDE.
+Le programme principal est donné à l'[Étape 2 : Programmer](#étape-2--programmer) ci-dessous. Copiez-le dans votre IDE.
 
 <figure style={{textAlign: 'center', margin: '1rem auto'}}>
   <img
@@ -191,12 +191,12 @@ screen.show()                           # affiche enfin ce qu'on a préparé sur
 
 La fonction **`screen.text(texte, at=..., color=..., scale=...)`** permet d'afficher du texte sans calculer de coordonnées en pixels : il suffit d'indiquer une **ancre cardinale** parmi celles décrites à l'[étape 1, section « Repérer la géométrie de l'écran »](#3-repérer-la-géométrie-de-lécran), ou un couple de coordonnées explicites.
 
-Deux raccourcis pratiques structurent l'affichage : `screen.title()` place un texte en haut en `GRAY`, `screen.subtitle()` un texte en bas en `DARK` — pas besoin de préciser position ni couleur.
+Deux raccourcis pratiques structurent l'affichage : `screen.title()` place un texte en haut en `GRAY`, `screen.subtitle()` un texte en bas en `DARK`. Pas besoin de préciser position ni couleur.
 
 Couleurs disponibles dans `steami_screen` : `BLACK`, `DARK`, `GRAY`, `LIGHT`, `WHITE` (5 niveaux de gris du SSD1327), plus `RED`, `GREEN`, `BLUE`, `YELLOW` (qui dégradent automatiquement en niveaux de gris sur l'écran monochrome).
 
 :::warning Étape importante : `screen.show()`
-On peut imaginer l'écran de la STeaMi comme un tableau noir caché derrière un voile. Les fonctions `text()`, `clear()`, `pixel()`… dessinent sur le tableau, mais le voile reste en place tant qu'on n'a pas appelé `screen.show()`. À ce moment-là, le voile tombe et tout ce qu'on a dessiné apparaît d'un coup.
+On peut imaginer l'écran de la STeaMi comme un tableau noir caché derrière un voile. Les fonctions `text()`, `clear()`, `pixel()`, etc. dessinent sur le tableau, mais le voile reste en place tant qu'on n'a pas appelé `screen.show()`. À ce moment-là, le voile tombe et tout ce qu'on a dessiné apparaît d'un coup.
 
 Techniquement, ce « tableau caché » s'appelle un **framebuffer** : une zone de mémoire dans laquelle on prépare l'image, avant de la transférer vers l'écran.
 :::
@@ -273,7 +273,7 @@ while True:
     style={{maxWidth: '450px', width: '100%', height: 'auto', borderRadius: '8px', border: '1px solid #eee', boxShadow: '0 2px 8px rgba(0,0,0,0.05)'}}
   />
   <figcaption style={{fontStyle: 'italic', marginTop: '0.5rem'}}>
-    Le personnage |_ qui traverse l'écran : effacer → dessiner → afficher → attendre.
+    Le personnage |_ qui traverse l'écran : effacer, dessiner, afficher, attendre, puis recommencer.
   </figcaption>
 </figure>
 
@@ -333,14 +333,14 @@ Une fois la mise en page maîtrisée, brancher de vraies valeurs en lisant les c
 
 ### Pour comprendre
 
-- **[OLED — Wikipedia](https://fr.wikipedia.org/wiki/Diode_%C3%A9lectroluminescente_organique)** : la technologie d'écran utilisée par la STeaMi. Contrairement à un LCD, chaque pixel émet sa propre lumière (pas de rétro-éclairage), ce qui permet des noirs profonds et une consommation très basse quand peu de pixels sont allumés.
-- **[Pixel art — Wikipedia](https://fr.wikipedia.org/wiki/Pixel_art)** : histoire et esthétique du dessin en pixels — des premiers jeux vidéo aux installations contemporaines. Quand chaque pixel compte, la contrainte devient un style.
-- **[Framebuffer — Wikipedia](https://fr.wikipedia.org/wiki/Tampon_d%27image)** : le « tableau caché » qu'on prépare avant de l'envoyer à l'écran. Concept fondateur du graphisme moderne, présent depuis les GPU jusqu'aux navigateurs web.
+- **[OLED (Wikipedia)](https://fr.wikipedia.org/wiki/Diode_%C3%A9lectroluminescente_organique)** : la technologie d'écran utilisée par la STeaMi. Contrairement à un LCD, chaque pixel émet sa propre lumière (pas de rétro-éclairage), ce qui permet des noirs profonds et une consommation très basse quand peu de pixels sont allumés.
+- **[Pixel art (Wikipedia)](https://fr.wikipedia.org/wiki/Pixel_art)** : histoire et esthétique du dessin en pixels, des premiers jeux vidéo aux installations contemporaines. Quand chaque pixel compte, la contrainte devient un style.
+- **[Framebuffer (Wikipedia)](https://fr.wikipedia.org/wiki/Tampon_d%27image)** : le « tableau caché » qu'on prépare avant de l'envoyer à l'écran. Concept fondateur du graphisme moderne, présent depuis les GPU jusqu'aux navigateurs web.
 
 ### Pour s'inspirer
 
-- **[Jenny Holzer — Survival Series (Centre Pompidou)](https://www.centrepompidou.fr/fr/ressources/oeuvre/c888Bex)** : depuis Times Square en 1982, l'artiste a fait du panneau LED un médium à part entière. Des messages diffusés en lumière, programmés pour défiler, qui interrogent la société.
-- **[Pixel Revival : quand l'esthétique 8-bit redéfinit les codes du design graphique (Étapes)](https://www.etapes.com/2025/04/18/pixel-revival-quand-lesthetique-8-bit-redefinit-les-codes-du-design-graphique/)** : comment la contrainte du pixel — autrefois subie — est devenue une esthétique revendiquée dans le design contemporain.
+- **[Jenny Holzer, Survival Series (Centre Pompidou)](https://www.centrepompidou.fr/fr/ressources/oeuvre/c888Bex)** : depuis Times Square en 1982, l'artiste a fait du panneau LED un médium à part entière. Des messages diffusés en lumière, programmés pour défiler, qui interrogent la société.
+- **[Pixel Revival : quand l'esthétique 8-bit redéfinit les codes du design graphique (Étapes)](https://www.etapes.com/2025/04/18/pixel-revival-quand-lesthetique-8-bit-redefinit-les-codes-du-design-graphique/)** : comment la contrainte du pixel, autrefois subie, est devenue une esthétique revendiquée dans le design contemporain.
 - **[Susan Kare et les icônes du Macintosh](https://fr.wikipedia.org/wiki/Susan_Kare)** : la designer qui a dessiné les premières icônes du Mac en 1984 sur une grille de 16 × 16 pixels. Une démonstration magistrale de ce qu'on peut exprimer avec très peu de pixels.
 
 ---

--- a/site/docs/inovmicro-exao/t03-decouverte-thonny.md
+++ b/site/docs/inovmicro-exao/t03-decouverte-thonny.md
@@ -34,12 +34,12 @@ sidebar_position: 3
 
 ## De quoi parle-t-on ?
 
-Programmer une carte microcontrôleur peut sembler intimidant : plusieurs logiciels à installer, environnement à configurer, code à envoyer vers la carte…
+Programmer une carte microcontrôleur peut sembler intimidant : plusieurs logiciels à installer, environnement à configurer, code à envoyer vers la carte...
 **Thonny** est un éditeur Python conçu pour l'apprentissage qui simplifie cette mise en route. Couplé à **MicroPython** : une version de Python adaptée aux cartes électroniques, une fois installé sur la STeaMi, il offre un environnement **gratuit et hors-ligne** où l'on peut écrire du code, le tester en direct dans le **REPL** (une fenêtre de dialogue où l'on tape une instruction et la carte y répond immédiatement), et déboguer pas-à-pas.
 
 Cette fiche met en place tout l'environnement de travail : installation de Thonny, installation de MicroPython sur la carte, configuration de la communication entre Thonny et la carte, et écriture d'un premier programme qui pilote la **LED RGB** de la STeaMi avec ses **boutons A et B**. À privilégier en salle informatique avec postes fixes ; pour des postes verrouillés ou en mobilité, préférer **Vittascience** (en ligne).
 
-Thonny n'est qu'un choix parmi d'autres : tout éditeur compatible MicroPython (Mu, VS Code, Vittascience, mpremote…) permet de programmer la STeaMi de la même façon. Cette fiche s'appuie sur Thonny pour fixer les idées, mais la démarche reste valable sur d'autres outils.
+Thonny n'est qu'un choix parmi d'autres : tout éditeur compatible MicroPython (Mu, VS Code, Vittascience, mpremote, etc.) permet de programmer la STeaMi de la même façon. Cette fiche s'appuie sur Thonny pour fixer les idées, mais la démarche reste valable sur d'autres outils.
 
 ---
 
@@ -79,7 +79,7 @@ pipx install thonny
     style={{maxWidth: '100%', height: 'auto'}}
   />
   <figcaption style={{fontStyle: 'italic', marginTop: '0.5rem'}}>
-    Thonny au premier lancement : éditeur en haut, **panneau Shell** en bas — c'est la console interactive de MicroPython (aussi appelée **REPL**, pour _Read-Eval-Print Loop_) où l'on peut taper une commande et voir la carte y répondre immédiatement.
+    Thonny au premier lancement : éditeur en haut, **panneau Shell** en bas. C'est la console interactive de MicroPython (aussi appelée **REPL**, pour _Read-Eval-Print Loop_) où l'on peut taper une commande et voir la carte y répondre immédiatement.
   </figcaption>
 </figure>
 
@@ -87,7 +87,7 @@ pipx install thonny
 
 :::info Étape éventuellement déjà faite
 
-Une STeaMi sortie d'usine est en général livrée avec MicroPython déjà installé. Si après l'étape suivante (*Configurer Thonny pour la STeaMi*) l'invite `>>>` apparaît dans le Shell de Thonny (le signe en début de ligne qui indique que MicroPython attend une commande — équivalent du mot anglais « prompt »), cette étape d'installation est déjà faite : passez directement à la section suivante.
+Une STeaMi sortie d'usine est en général livrée avec MicroPython déjà installé. Si après l'étape suivante (*Configurer Thonny pour la STeaMi*) l'invite `>>>` apparaît dans le Shell de Thonny (le signe en début de ligne qui indique que MicroPython attend une commande, équivalent du mot anglais « prompt »), cette étape d'installation est déjà faite : passez directement à la section suivante.
 
 :::
 
@@ -116,15 +116,15 @@ Si le disque `STEAMI` n'apparaît pas, le premier réflexe est de changer de câ
 </figure>
 
 ### Configurer Thonny pour la STeaMi
-Si Thonny démarre en anglais : **Tools → Options → onglet General → Language: Français**, puis redémarrer Thonny. La suite utilise les libellés français.
+Si Thonny démarre en anglais : **Tools > Options > onglet General > Language: Français**, puis redémarrer Thonny. La suite utilise les libellés français.
 
 1. Ouvrir Thonny.
-2. **Outils → Options… → onglet Interpréteur** (le terme employé par Thonny pour désigner l'appareil sur lequel le code va s'exécuter).
+2. **Outils > Options... > onglet Interpréteur** (le terme employé par Thonny pour désigner l'appareil sur lequel le code va s'exécuter).
 3. Liste **Quel interpréteur ou appareil utiliser** : choisir **MicroPython (generic)**.
 4. **Port** (la prise par laquelle l'ordinateur dialogue avec la carte) : sélectionner celui de la STeaMi.
    - Linux : `/dev/ttyACM0`
    - macOS : `/dev/cu.usbmodemXXXX`
-   - Windows : `COM3`, `COM4`…
+   - Windows : `COM3`, `COM4`, etc.
 5. Cliquer **OK**.
 :::info[Identifier le bon port]
 
@@ -151,7 +151,7 @@ Type "help()" for more information.
     style={{maxWidth: '100%', height: 'auto'}}
   />
   <figcaption style={{fontStyle: 'italic', marginTop: '0.5rem'}}>
-    Outils → Options → Interpréteur : choisir « MicroPython (generic) » et le port de la STeaMi.
+    Outils > Options > Interpréteur : choisir « MicroPython (generic) » et le port de la STeaMi.
   </figcaption>
 </figure>
 <figure style={{textAlign: 'center', margin: '1rem auto'}}>
@@ -239,7 +239,7 @@ while True:
 ### Exécution
 
 - **Test rapide** : bouton **Run** (▶) ou `F5`. Le code s'exécute sur la carte sans être sauvegardé.
-- **Programme persistant** : **Fichier → Enregistrer sous… → MicroPython device**, et nommer le fichier **`main.py`**. Il sera relancé à chaque démarrage de la carte.
+- **Programme persistant** : **Fichier > Enregistrer sous... > MicroPython device**, et nommer le fichier **`main.py`**. Il sera relancé à chaque démarrage de la carte.
 
 :::info Un programme est déjà en cours d'exécution
 
@@ -334,7 +334,7 @@ Raccourcis utiles dans le REPL :
 Thonny propose un débogueur intégré, particulièrement adapté à l'enseignement :
 
 1. Cliquer dans la marge à gauche d'une ligne pour poser un **point d'arrêt**.
-2. **Run → Debug current script** (`Ctrl+F5`).
+2. **Run > Debug current script** (`Ctrl+F5`).
 3. Avancer avec **Step over** (`F6`), **Step into** (`F7`), **Step out** (`F8`).
 4. Observer les variables dans le panneau **Variables**.
 :::tip[Limite à connaître]
@@ -371,9 +371,9 @@ La plupart des problèmes rencontrés en classe ne sont pas spécifiques à Thon
 
 ### Pour s'inspirer
 
-- **[MOOC FUN — Programmer un objet avec MicroPython](https://www.fun-mooc.fr/fr/cours/programmer-un-objet-avec-micropython/)** : un cours en ligne gratuit (CC-BY-SA) qui couvre les bases de MicroPython sur Pyboard / ESP32 / micro:bit. Idéal en complément pour s'approprier le langage et son écosystème, avant de l'enseigner.
-- **[L'histoire de MicroPython](https://fr.wikipedia.org/wiki/MicroPython)** : lancé en 2013 par Damien George via une campagne Kickstarter, MicroPython est une **implémentation de Python** pensée pour les systèmes embarqués — un interpréteur compact capable de tourner sur des cartes avec très peu de mémoire, qui a démocratisé Python sur microcontrôleur.
-- **[Thonny — pensé pour l'enseignement](https://thonny.org/)** : conçu par Aivar Annamaa (Université de Tartu) pour rendre Python accessible aux débutant·es. Visualisation pas-à-pas des variables, débogueur didactique, installation sans dépendance.
+- **[MOOC FUN, Programmer un objet avec MicroPython](https://www.fun-mooc.fr/fr/cours/programmer-un-objet-avec-micropython/)** : un cours en ligne gratuit (CC-BY-SA) qui couvre les bases de MicroPython sur Pyboard / ESP32 / micro:bit. Idéal en complément pour s'approprier le langage et son écosystème, avant de l'enseigner.
+- **[L'histoire de MicroPython](https://fr.wikipedia.org/wiki/MicroPython)** : lancé en 2013 par Damien George via une campagne Kickstarter, MicroPython est une **implémentation de Python** pensée pour les systèmes embarqués, un interpréteur compact capable de tourner sur des cartes avec très peu de mémoire, qui a démocratisé Python sur microcontrôleur.
+- **[Thonny, pensé pour l'enseignement](https://thonny.org/)** : conçu par Aivar Annamaa (Université de Tartu) pour rendre Python accessible aux débutant·es. Visualisation pas-à-pas des variables, débogueur didactique, installation sans dépendance.
 
 ### Pour approfondir
 


### PR DESCRIPTION
## Résumé

Cleanup global des 6 fiches I-NOVMICRO publiées pour aligner sur la règle adoptée dans #134 (pas de cadratins / ellipsis Unicode / flèches dans les fiches).

| Caractère | Occurrences |
|---|---|
| **Cadratin** (`—`, U+2014) | 39 |
| **Ellipsis Unicode** (`…`, U+2026) | 13 |
| **Flèche** (`→`, U+2192) | 12 |

## Remplacements appliqués

- `—` en parenthétique → `. ` / ` : ` / `(...)` selon le contexte
- `[X — Wikipedia]` → `[X (Wikipedia)]` dans les liens
- `[X — sous-titre]` → `[X, sous-titre]`
- `…` (Unicode) → `...` (3 points ASCII)
- `…` en énumération ouverte → `, etc.`
- `Outils → Options` (navigation menu IDE) → `Outils > Options`
- `A → B` sémantique → reformulation en mots (« A allume B », « effacer, dessiner, afficher, attendre »)

## Au passage

Suppression de la phrase « Attention : un câble qui ne sert qu'à charger un téléphone ne fonctionnera pas. » des fiches i04, i06 et i10 (alignement avec #134, déjà retirée sur i01).

## Fichiers touchés

- `site/docs/inovmicro-exao/i01-led.md`
- `site/docs/inovmicro-exao/i04-capteur-lumiere.md`
- `site/docs/inovmicro-exao/i06-code-morse.md`
- `site/docs/inovmicro-exao/i10-texte-oled.md`
- `site/docs/inovmicro-exao/depannage.md`
- `site/docs/inovmicro-exao/t03-decouverte-thonny.md`

Aucun changement de structure ni de fond pédagogique. Seulement du polish de caractères.

## Test plan

- [x] `npm run lint:md`
- [x] `npm run lint:spell` (201 fichiers OK)
- [x] `npm run lint:crosslinks` (réciprocité préservée)
- [x] `npm run site:build`
- [x] Vérification finale : `grep -c "—\|…\|→"` retourne 0 sur les 6 fiches
- [ ] Revue humaine