### PR TITLE
ci(commitlint): exempte les messages des GitHub Actions tierces

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -4,8 +4,9 @@ module.exports = {
   // sur les PRs (et ne suivent pas Conventional Commits). On ne discipline
   // que les commits humains.
   // - calibreapp/image-actions (workflow optimize-images.yml) : message
-  //   non négociable côté action sur la 1.4.1 ; voir issue #154 pour le
-  //   passage à un message conforme une fois la PR #151 mergée.
+  //   `Optimised images with calibre/image-actions` hardcodé côté action
+  //   (pas d'input pour le personnaliser, vérifié sur 1.4.1 et 1.5.0).
+  //   Cette exception est notre solution durable, cf. décision sur #154.
   ignores: [(msg) => msg.startsWith('Optimised images with calibre/image-actions')],
   rules: {
     'subject-case': [0],

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -7,7 +7,11 @@ module.exports = {
   //   `Optimised images with calibre/image-actions` hardcodé côté action
   //   (pas d'input pour le personnaliser, vérifié sur 1.4.1 et 1.5.0).
   //   Cette exception est notre solution durable, cf. décision sur #154.
-  ignores: [(msg) => msg.startsWith('Optimised images with calibre/image-actions')],
+  // Match strict sur la 1ʳᵉ ligne du commit (pas `startsWith`) pour qu'un
+  // humain ne puisse pas bypasser commitlint en préfixant son message par
+  // cette chaîne. Le body éventuel ajouté un jour par l'action n'est pas
+  // contraint.
+  ignores: [(msg) => msg.split('\n', 1)[0] === 'Optimised images with calibre/image-actions'],
   rules: {
     'subject-case': [0],
     'scope-enum': [

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -6,9 +6,7 @@ module.exports = {
   // - calibreapp/image-actions (workflow optimize-images.yml) : message
   //   non négociable côté action sur la 1.4.1 ; voir issue #154 pour le
   //   passage à un message conforme une fois la PR #151 mergée.
-  ignores: [
-    (msg) => msg.startsWith('Optimised images with calibre/image-actions'),
-  ],
+  ignores: [(msg) => msg.startsWith('Optimised images with calibre/image-actions')],
   rules: {
     'subject-case': [0],
     'scope-enum': [

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,5 +1,14 @@
 module.exports = {
   extends: ['@commitlint/config-conventional'],
+  // Exempte les messages générés par des GitHub Actions tierces qui poussent
+  // sur les PRs (et ne suivent pas Conventional Commits). On ne discipline
+  // que les commits humains.
+  // - calibreapp/image-actions (workflow optimize-images.yml) : message
+  //   non négociable côté action sur la 1.4.1 ; voir issue #154 pour le
+  //   passage à un message conforme une fois la PR #151 mergée.
+  ignores: [
+    (msg) => msg.startsWith('Optimised images with calibre/image-actions'),
+  ],
   rules: {
     'subject-case': [0],
     'scope-enum': [


### PR DESCRIPTION
## Résumé

Ajoute une règle `ignores` à `commitlint.config.js` pour exempter le commit auto-poussé par `calibreapp/image-actions` (message `Optimised images with calibre/image-actions`), qui fait planter le check **Lint commit messages** avec `subject-empty` + `type-empty`. Cas observé sur la PR #134 (5 commits du bot rejetés).

Diff :

```js
ignores: [
  (msg) => msg.startsWith('Optimised images with calibre/image-actions'),
],
```

C'est un patch ciblé : commitlint reste discipliné pour les humains. La PR #151 réduit déjà le nombre de commits parasites du bot ; l'option `commitMessage` de calibre permettra plus tard de produire un message conforme (issue #154, à traiter après merge de #151).

## Type de changement

- [ ] Contenu — fiche, doc, texte
- [ ] Catalogue — entrée(s) dans `resources.ts` ou `projects.ts`
- [ ] Code — composant React, page, type, CSS
- [x] Configuration — config Docusaurus, CI, hooks
- [ ] Assets — images, PDFs, vidéos

## Test plan

Tests locaux exécutés depuis le worktree (`npx commitlint`) :

- [x] `Optimised images with calibre/image-actions` → **ignoré** (exit 0).
- [x] `random non-conventional message` → **rejeté** (exit non-zero, subject-empty + type-empty) — la discipline humaine reste.
- [x] `feat(inovmicro-exao): foo bar` → **accepté**.

## Issues liées

Closes #153
Refs #134, #151, #154