### PR TITLE
feat(code): ajoute un bouton « Écouter » au composant ABCNotation

### DIFF
--- a/site/src/components/ABCNotation/index.tsx
+++ b/site/src/components/ABCNotation/index.tsx
@@ -145,6 +145,19 @@ function ABCNotationClient({
     });
   }
 
+  // Convertit une position diatonique abcjs (`abcElem.pitches[i].pitch`)
+  // en pitch MIDI absolu. La convention abcjs : 0 = C4 (Do central, MIDI
+  // 60), chaque unité = un degré de la gamme diatonique de la tonalité.
+  // En `K:C` les degrés sont C-D-E-F-G-A-B (offsets en demi-tons :
+  // 0-2-4-5-7-9-11). Pour les autres tonalités, abcjs ajuste déjà via
+  // `accidental` au niveau de chaque pitch — on s'aligne donc dessus.
+  function diatonicToMidi(diatonic: number, accidental: number | undefined): number {
+    const semitones = [0, 2, 4, 5, 7, 9, 11];
+    const octave = Math.floor(diatonic / 7);
+    const step = ((diatonic % 7) + 7) % 7;
+    return 60 + octave * 12 + semitones[step] + (accidental ?? 0);
+  }
+
   // Joue une seule note via abcjs.synth.playEvent. Utilisé par le
   // clickListener pour rendre chaque note interactive (en particulier
   // dans le tableau des 7 notes Do…Si). `playEvent` gère son propre
@@ -154,14 +167,35 @@ function ABCNotationClient({
   async function playSingleNote(abcElem: any) {
     const abcjs = abcjsRef.current;
     if (!abcjs?.synth?.playEvent) return;
-    if (!abcElem?.midiPitches?.length) return;
+
+    // En mode `inline` (M:none, L:1/4) abcjs ne génère pas toujours
+    // `midiPitches`. On le reconstruit alors depuis `abcElem.pitches`,
+    // qui reste fourni avec la position diatonique + altération.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let midiPitches: any[] | undefined = abcElem?.midiPitches;
+    if ((!midiPitches || midiPitches.length === 0) && Array.isArray(abcElem?.pitches)) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      midiPitches = abcElem.pitches.map((p: any) => ({
+        cmd: 'note',
+        pitch: diatonicToMidi(
+          typeof p?.pitch === 'number' ? p.pitch : 0,
+          typeof p?.accidental === 'number' ? p.accidental : undefined,
+        ),
+        volume: 80,
+        start: 0,
+        duration: typeof p?.duration === 'number' && p.duration > 0 ? p.duration : 0.5,
+        instrument: 0,
+      }));
+    }
+    if (!midiPitches || midiPitches.length === 0) return;
+
     try {
       const visualObj = visualObjRef.current;
       const ms =
         typeof visualObj?.millisecondsPerMeasure === 'function'
           ? visualObj.millisecondsPerMeasure()
           : 1000;
-      await abcjs.synth.playEvent(abcElem.midiPitches, [], ms);
+      await abcjs.synth.playEvent(midiPitches, [], ms);
     } catch (e) {
       // eslint-disable-next-line no-console
       console.error('ABCNotation note click play failed:', e);

--- a/site/src/components/ABCNotation/index.tsx
+++ b/site/src/components/ABCNotation/index.tsx
@@ -196,6 +196,25 @@ function ABCNotationClient({
           ? visualObj.millisecondsPerMeasure()
           : 1000;
       await abcjs.synth.playEvent(midiPitches, [], ms);
+
+      // abcjs ajoute la classe `abcjs-note_selected` (rouge) sur la note
+      // cliquée et la laisse en place jusqu'à un autre clic. On la retire
+      // à la fin de la note pour revenir au noir et signaler que le son
+      // est terminé. Durée = somme des `duration` (en "whole notes")
+      // multipliée par `millisecondsPerMeasure`.
+      const totalWholeNotes = midiPitches.reduce(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (max: number, p: any) => Math.max(max, (p.start ?? 0) + (p.duration ?? 0.5)),
+        0,
+      );
+      const noteDurationMs = Math.max(150, ms * totalWholeNotes + 100);
+      window.setTimeout(() => {
+        const root = containerRef.current;
+        if (!root) return;
+        root.querySelectorAll('.abcjs-note_selected').forEach((el) => {
+          el.classList.remove('abcjs-note_selected');
+        });
+      }, noteDurationMs);
     } catch (e) {
       // eslint-disable-next-line no-console
       console.error('ABCNotation note click play failed:', e);

--- a/site/src/components/ABCNotation/index.tsx
+++ b/site/src/components/ABCNotation/index.tsx
@@ -119,6 +119,13 @@ function ABCNotationClient({
         audioCtxRef.current.close().catch(() => undefined);
         audioCtxRef.current = null;
       }
+      // Réinitialise les états UI : si l'effet se relance (changement de
+      // `children`, `inline`…) on a stoppé le son ci-dessus, donc le
+      // bouton ne doit plus afficher « ⏹ Arrêter » ou « ⏳ Chargement… ».
+      // setState dans un cleanup est sans effet à l'unmount (React le
+      // détecte) et propre lors d'un re-déclenchement d'effet.
+      setIsPlaying(false);
+      setIsLoadingAudio(false);
     };
   }, [children, effectiveResponsive, effectiveStaffWidth, inline]);
 

--- a/site/src/components/ABCNotation/index.tsx
+++ b/site/src/components/ABCNotation/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, type ReactNode } from 'react';
+import { useEffect, useRef, useState, type ReactNode } from 'react';
 import BrowserOnly from '@docusaurus/BrowserOnly';
 import styles from './styles.module.css';
 
@@ -18,6 +18,20 @@ function ABCNotationClient({
   inline = false,
 }: ABCNotationProps) {
   const containerRef = useRef<HTMLElement | null>(null);
+  // Types abcjs non exposés en TS strict : on garde any pour cette première
+  // exploration audio. À typer correctement quand le contrat sera figé.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const visualObjRef = useRef<any>(null);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const abcjsRef = useRef<any>(null);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const synthRef = useRef<any>(null);
+  const audioCtxRef = useRef<AudioContext | null>(null);
+  const stopTimerRef = useRef<number | null>(null);
+  const [audioSupported, setAudioSupported] = useState(false);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [isLoadingAudio, setIsLoadingAudio] = useState(false);
+
   const effectiveResponsive = responsive ?? !inline;
   const effectiveStaffWidth = staffwidth ?? (inline ? 60 : 740);
 
@@ -25,8 +39,10 @@ function ABCNotationClient({
     let cancelled = false;
     import('abcjs').then((mod) => {
       if (cancelled || !containerRef.current) return;
-      const abcjs = mod.default ?? mod;
-      abcjs.renderAbc(containerRef.current, children, {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const abcjs: any = (mod as any).default ?? mod;
+      abcjsRef.current = abcjs;
+      const visualObjs = abcjs.renderAbc(containerRef.current, children, {
         responsive: effectiveResponsive ? 'resize' : undefined,
         staffwidth: effectiveStaffWidth,
         paddingleft: 0,
@@ -35,6 +51,15 @@ function ABCNotationClient({
         paddingbottom: 0,
         scale: inline ? 0.7 : 1,
       });
+      visualObjRef.current = visualObjs?.[0] ?? null;
+
+      // Le synthé n'est exposé qu'en mode non-inline (UX trop chargée
+      // pour les mini-portées d'illustration). `supportsAudio` vérifie
+      // que WebAudio est dispo côté navigateur.
+      if (!inline && abcjs.synth && typeof abcjs.synth.supportsAudio === 'function') {
+        setAudioSupported(Boolean(abcjs.synth.supportsAudio()));
+      }
+
       if (inline && containerRef.current) {
         const svg = containerRef.current.querySelector('svg');
         if (svg) {
@@ -51,12 +76,104 @@ function ABCNotationClient({
     });
     return () => {
       cancelled = true;
+      if (stopTimerRef.current !== null) {
+        window.clearTimeout(stopTimerRef.current);
+        stopTimerRef.current = null;
+      }
+      if (synthRef.current) {
+        try {
+          synthRef.current.stop();
+        } catch {
+          /* noop */
+        }
+        synthRef.current = null;
+      }
+      if (audioCtxRef.current) {
+        audioCtxRef.current.close().catch(() => undefined);
+        audioCtxRef.current = null;
+      }
     };
   }, [children, effectiveResponsive, effectiveStaffWidth, inline]);
 
   const setRef = (el: HTMLElement | null) => {
     containerRef.current = el;
   };
+
+  async function handlePlay() {
+    const abcjs = abcjsRef.current;
+    const visualObj = visualObjRef.current;
+    if (!abcjs || !visualObj) return;
+
+    setIsLoadingAudio(true);
+    try {
+      // L'AudioContext ne peut être créé que dans le gestionnaire d'un geste
+      // utilisateur (Chrome/Safari). Comme handlePlay est branché sur onClick,
+      // on est OK.
+      if (!audioCtxRef.current) {
+        const AC =
+          window.AudioContext ??
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (window as any).webkitAudioContext;
+        audioCtxRef.current = new AC();
+      }
+      if (audioCtxRef.current!.state === 'suspended') {
+        await audioCtxRef.current!.resume();
+      }
+
+      const synth = new abcjs.synth.CreateSynth();
+      await synth.init({
+        visualObj,
+        audioContext: audioCtxRef.current,
+        millisecondsPerMeasure:
+          typeof visualObj.millisecondsPerMeasure === 'function'
+            ? visualObj.millisecondsPerMeasure()
+            : undefined,
+      });
+      await synth.prime();
+      synthRef.current = synth;
+      synth.start();
+      setIsPlaying(true);
+
+      // CreateSynth ne signale pas la fin de lecture : on déclenche un
+      // timer basé sur la durée totale + petite marge.
+      const totalSec =
+        typeof visualObj.getTotalTime === 'function' ? Number(visualObj.getTotalTime()) : 0;
+      if (totalSec > 0) {
+        stopTimerRef.current = window.setTimeout(
+          () => {
+            setIsPlaying(false);
+            synthRef.current = null;
+            stopTimerRef.current = null;
+          },
+          totalSec * 1000 + 200,
+        );
+      }
+    } catch (e) {
+      // En cas d'échec (soundfont indisponible, autorisation audio),
+      // on log et on remet le bouton en état initial.
+      // eslint-disable-next-line no-console
+      console.error('ABCNotation audio play failed:', e);
+      setIsPlaying(false);
+    } finally {
+      setIsLoadingAudio(false);
+    }
+  }
+
+  function handleStop() {
+    if (stopTimerRef.current !== null) {
+      window.clearTimeout(stopTimerRef.current);
+      stopTimerRef.current = null;
+    }
+    if (synthRef.current) {
+      try {
+        synthRef.current.stop();
+      } catch {
+        /* noop */
+      }
+      synthRef.current = null;
+    }
+    setIsPlaying(false);
+  }
 
   if (inline) {
     return (
@@ -67,6 +184,19 @@ function ABCNotationClient({
   return (
     <figure className={styles.figure}>
       <div ref={setRef} className={styles.score} aria-label="Partition musicale" />
+      {audioSupported && (
+        <div className={styles.controls}>
+          <button
+            type="button"
+            className={styles.playButton}
+            onClick={isPlaying ? handleStop : handlePlay}
+            disabled={isLoadingAudio}
+            aria-label={isPlaying ? 'Arrêter la lecture' : 'Écouter la mélodie'}
+          >
+            {isLoadingAudio ? '⏳ Chargement…' : isPlaying ? '⏹ Arrêter' : '▶ Écouter'}
+          </button>
+        </div>
+      )}
       {caption && <figcaption className={styles.caption}>{caption}</figcaption>}
     </figure>
   );

--- a/site/src/components/ABCNotation/index.tsx
+++ b/site/src/components/ABCNotation/index.tsx
@@ -189,32 +189,37 @@ function ABCNotationClient({
     }
     if (!midiPitches || midiPitches.length === 0) return;
 
-    try {
-      const visualObj = visualObjRef.current;
-      const ms =
-        typeof visualObj?.millisecondsPerMeasure === 'function'
-          ? visualObj.millisecondsPerMeasure()
-          : 1000;
-      await abcjs.synth.playEvent(midiPitches, [], ms);
+    const visualObj = visualObjRef.current;
+    const ms =
+      typeof visualObj?.millisecondsPerMeasure === 'function'
+        ? visualObj.millisecondsPerMeasure()
+        : 1000;
 
-      // abcjs ajoute la classe `abcjs-note_selected` (rouge) sur la note
-      // cliquée et la laisse en place jusqu'à un autre clic. On la retire
-      // à la fin de la note pour revenir au noir et signaler que le son
-      // est terminé. Durée = somme des `duration` (en "whole notes")
-      // multipliée par `millisecondsPerMeasure`.
-      const totalWholeNotes = midiPitches.reduce(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (max: number, p: any) => Math.max(max, (p.start ?? 0) + (p.duration ?? 0.5)),
-        0,
-      );
-      const noteDurationMs = Math.max(150, ms * totalWholeNotes + 100);
-      window.setTimeout(() => {
-        const root = containerRef.current;
-        if (!root) return;
-        root.querySelectorAll('.abcjs-note_selected').forEach((el) => {
-          el.classList.remove('abcjs-note_selected');
+    // abcjs ajoute la classe `abcjs-note_selected` (rouge) sur la note
+    // cliquée et la laisse en place jusqu'à un autre clic. On la retire
+    // à la fin du son pour revenir au noir et signaler que le son est
+    // terminé. On programme le timer EN PARALLÈLE de `playEvent` (pas
+    // après son `await`) car selon les versions d'abcjs, la Promise
+    // peut ne jamais se résoudre — programmation indépendante plus sûre.
+    const totalWholeNotes = midiPitches.reduce(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (max: number, p: any) => Math.max(max, (p.start ?? 0) + (p.duration ?? 0.5)),
+      0,
+    );
+    const noteDurationMs = Math.max(150, ms * totalWholeNotes + 100);
+    window.setTimeout(() => {
+      // Cible scopée au container, avec fallback global au cas où abcjs
+      // poserait la classe sur un ancêtre hors du containerRef.
+      const root = containerRef.current ?? document;
+      root.querySelectorAll('.abcjs-note_selected, [class*="note_selected"]').forEach((el) => {
+        el.classList.forEach((cls) => {
+          if (cls.includes('note_selected')) el.classList.remove(cls);
         });
-      }, noteDurationMs);
+      });
+    }, noteDurationMs);
+
+    try {
+      await abcjs.synth.playEvent(midiPitches, [], ms);
     } catch (e) {
       // eslint-disable-next-line no-console
       console.error('ABCNotation note click play failed:', e);

--- a/site/src/components/ABCNotation/index.tsx
+++ b/site/src/components/ABCNotation/index.tsx
@@ -195,12 +195,17 @@ function ABCNotationClient({
         ? visualObj.millisecondsPerMeasure()
         : 1000;
 
-    // abcjs ajoute la classe `abcjs-note_selected` (rouge) sur la note
-    // cliquée et la laisse en place jusqu'à un autre clic. On la retire
-    // à la fin du son pour revenir au noir et signaler que le son est
-    // terminé. On programme le timer EN PARALLÈLE de `playEvent` (pas
-    // après son `await`) car selon les versions d'abcjs, la Promise
-    // peut ne jamais se résoudre — programmation indépendante plus sûre.
+    // abcjs ne pose pas de classe de sélection : il colorise les notes
+    // cliquées en mettant un attribut `fill` directement sur le `<g>`
+    // parent (les `path.abcjs-notehead` / `path.abcjs-stem` héritent en
+    // SVG, ou peuvent recevoir leur propre `fill`). Et cette couleur
+    // n'est jamais retirée tant qu'on ne re-clique pas ailleurs : les
+    // notes précédemment cliquées s'accumulent en rouge sur la portée.
+    // On nettoie tous les `[fill]` du containerRef à la fin du son.
+    //
+    // Timer programmé EN PARALLÈLE de `playEvent` (pas après son
+    // `await`) : selon les versions d'abcjs la Promise ne se résout
+    // pas toujours, donc on évite de dépendre du await.
     const totalWholeNotes = midiPitches.reduce(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (max: number, p: any) => Math.max(max, (p.start ?? 0) + (p.duration ?? 0.5)),
@@ -208,13 +213,10 @@ function ABCNotationClient({
     );
     const noteDurationMs = Math.max(150, ms * totalWholeNotes + 100);
     window.setTimeout(() => {
-      // Cible scopée au container, avec fallback global au cas où abcjs
-      // poserait la classe sur un ancêtre hors du containerRef.
-      const root = containerRef.current ?? document;
-      root.querySelectorAll('.abcjs-note_selected, [class*="note_selected"]').forEach((el) => {
-        el.classList.forEach((cls) => {
-          if (cls.includes('note_selected')) el.classList.remove(cls);
-        });
+      const root = containerRef.current;
+      if (!root) return;
+      root.querySelectorAll('svg [fill]').forEach((el) => {
+        el.removeAttribute('fill');
       });
     }, noteDurationMs);
 

--- a/site/src/components/ABCNotation/index.tsx
+++ b/site/src/components/ABCNotation/index.tsx
@@ -26,6 +26,10 @@ function ABCNotationClient({
   const abcjsRef = useRef<any>(null);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const synthRef = useRef<any>(null);
+  // TimingCallbacks d'abcjs : déclenche un événement par note pendant la
+  // lecture, on s'en sert pour highlighter la note en cours sur la portée.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const timingCallbacksRef = useRef<any>(null);
   const audioCtxRef = useRef<AudioContext | null>(null);
   const stopTimerRef = useRef<number | null>(null);
   const [audioSupported, setAudioSupported] = useState(false);
@@ -42,6 +46,12 @@ function ABCNotationClient({
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const abcjs: any = (mod as any).default ?? mod;
       abcjsRef.current = abcjs;
+      const supports = Boolean(
+        abcjs.synth &&
+        typeof abcjs.synth.supportsAudio === 'function' &&
+        abcjs.synth.supportsAudio(),
+      );
+
       const visualObjs = abcjs.renderAbc(containerRef.current, children, {
         responsive: effectiveResponsive ? 'resize' : undefined,
         staffwidth: effectiveStaffWidth,
@@ -50,14 +60,23 @@ function ABCNotationClient({
         paddingtop: 0,
         paddingbottom: 0,
         scale: inline ? 0.7 : 1,
+        // Clic sur une note → la joue. Branché aussi en mode inline pour
+        // le tableau des 7 notes (Do, Ré…) où c'est l'usage premier.
+        // `playEvent` gère son propre AudioContext interne.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        clickListener: supports
+          ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (abcElem: any) => {
+              void playSingleNote(abcElem);
+            }
+          : undefined,
       });
       visualObjRef.current = visualObjs?.[0] ?? null;
 
-      // Le synthé n'est exposé qu'en mode non-inline (UX trop chargée
-      // pour les mini-portées d'illustration). `supportsAudio` vérifie
-      // que WebAudio est dispo côté navigateur.
-      if (!inline && abcjs.synth && typeof abcjs.synth.supportsAudio === 'function') {
-        setAudioSupported(Boolean(abcjs.synth.supportsAudio()));
+      // Le bouton « Écouter » n'est exposé qu'en mode non-inline (UX
+      // trop chargée pour les mini-portées d'illustration).
+      if (!inline && supports) {
+        setAudioSupported(true);
       }
 
       if (inline && containerRef.current) {
@@ -80,6 +99,14 @@ function ABCNotationClient({
         window.clearTimeout(stopTimerRef.current);
         stopTimerRef.current = null;
       }
+      if (timingCallbacksRef.current) {
+        try {
+          timingCallbacksRef.current.stop();
+        } catch {
+          /* noop */
+        }
+        timingCallbacksRef.current = null;
+      }
       if (synthRef.current) {
         try {
           synthRef.current.stop();
@@ -98,6 +125,48 @@ function ABCNotationClient({
   const setRef = (el: HTMLElement | null) => {
     containerRef.current = el;
   };
+
+  function stopTimingCallbacks() {
+    if (timingCallbacksRef.current) {
+      try {
+        timingCallbacksRef.current.stop();
+      } catch {
+        /* noop */
+      }
+      timingCallbacksRef.current = null;
+    }
+  }
+
+  function clearCursorHighlights() {
+    const root = containerRef.current;
+    if (!root) return;
+    root.querySelectorAll(`.${styles.cursorHighlight}`).forEach((el) => {
+      el.classList.remove(styles.cursorHighlight);
+    });
+  }
+
+  // Joue une seule note via abcjs.synth.playEvent. Utilisé par le
+  // clickListener pour rendre chaque note interactive (en particulier
+  // dans le tableau des 7 notes Do…Si). `playEvent` gère son propre
+  // AudioContext et son propre soundfont, donc pas besoin de réutiliser
+  // celui de handlePlay.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async function playSingleNote(abcElem: any) {
+    const abcjs = abcjsRef.current;
+    if (!abcjs?.synth?.playEvent) return;
+    if (!abcElem?.midiPitches?.length) return;
+    try {
+      const visualObj = visualObjRef.current;
+      const ms =
+        typeof visualObj?.millisecondsPerMeasure === 'function'
+          ? visualObj.millisecondsPerMeasure()
+          : 1000;
+      await abcjs.synth.playEvent(abcElem.midiPitches, [], ms);
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error('ABCNotation note click play failed:', e);
+    }
+  }
 
   async function handlePlay() {
     const abcjs = abcjsRef.current;
@@ -131,6 +200,37 @@ function ABCNotationClient({
       });
       await synth.prime();
       synthRef.current = synth;
+
+      // TimingCallbacks : déclenche un eventCallback par note avec la
+      // référence aux SVG correspondants. On s'en sert pour highlighter
+      // la note en cours sur la portée pendant la lecture.
+      if (typeof abcjs.TimingCallbacks === 'function') {
+        const timing = new abcjs.TimingCallbacks(visualObj, {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          eventCallback: (ev: any) => {
+            clearCursorHighlights();
+            if (!ev) return;
+            // ev.elements est un array d'arrays de SVG elements (un par
+            // voix). On highlight chaque élément graphique de chaque voix.
+            if (Array.isArray(ev.elements)) {
+              ev.elements.forEach(
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                (voice: any[]) => {
+                  if (!Array.isArray(voice)) return;
+                  voice.forEach((el) => {
+                    if (el && typeof el.classList?.add === 'function') {
+                      el.classList.add(styles.cursorHighlight);
+                    }
+                  });
+                },
+              );
+            }
+          },
+        });
+        timing.start();
+        timingCallbacksRef.current = timing;
+      }
+
       synth.start();
       setIsPlaying(true);
 
@@ -144,6 +244,8 @@ function ABCNotationClient({
             setIsPlaying(false);
             synthRef.current = null;
             stopTimerRef.current = null;
+            stopTimingCallbacks();
+            clearCursorHighlights();
           },
           totalSec * 1000 + 200,
         );
@@ -172,6 +274,8 @@ function ABCNotationClient({
       }
       synthRef.current = null;
     }
+    stopTimingCallbacks();
+    clearCursorHighlights();
     setIsPlaying(false);
   }
 

--- a/site/src/components/ABCNotation/styles.module.css
+++ b/site/src/components/ABCNotation/styles.module.css
@@ -89,3 +89,21 @@
   opacity: 0.6;
   cursor: progress;
 }
+
+/* Indique que les notes sont cliquables (clic = joue la note).
+   abcjs ajoute la classe `abcjs-note` sur les noteheads. */
+.score :global(.abcjs-note),
+.inline :global(.abcjs-note) {
+  cursor: pointer;
+}
+
+/* Curseur de lecture : highlight la note en cours pendant le play.
+   abcjs nous donne les SVG elements via TimingCallbacks.eventCallback,
+   on leur ajoute `cursorHighlight`. La couleur reste lisible en mode
+   dark grâce à l'inversion appliquée plus haut sur le SVG. */
+.score :global(.abcjs-note).cursorHighlight,
+.score :global(.abcjs-rest).cursorHighlight,
+.score .cursorHighlight {
+  fill: var(--ifm-color-primary);
+  stroke: var(--ifm-color-primary);
+}

--- a/site/src/components/ABCNotation/styles.module.css
+++ b/site/src/components/ABCNotation/styles.module.css
@@ -52,3 +52,40 @@
 .inlineFallback {
   color: var(--ifm-color-emphasis-500);
 }
+
+.controls {
+  display: flex;
+  justify-content: center;
+  margin-top: 0.75rem;
+}
+
+.playButton {
+  appearance: none;
+  border: 1px solid var(--ifm-color-primary);
+  background: var(--ifm-color-primary);
+  color: var(--ifm-color-primary-contrast-foreground, #fff);
+  border-radius: 999px;
+  padding: 0.4rem 1.2rem;
+  font: inherit;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition:
+    background 0.15s ease,
+    border-color 0.15s ease,
+    opacity 0.15s ease;
+}
+
+.playButton:hover:not([disabled]) {
+  background: var(--ifm-color-primary-darker);
+  border-color: var(--ifm-color-primary-darker);
+}
+
+.playButton:focus-visible {
+  outline: 2px solid var(--ifm-color-primary-light);
+  outline-offset: 2px;
+}
+
+.playButton[disabled] {
+  opacity: 0.6;
+  cursor: progress;
+}


### PR DESCRIPTION
## Résumé

Première itération exploratoire pour ajouter de l'interactivité audio aux partitions ABC du site (voir [`site/docs/inovmicro-exao/i07-musique.md`](../blob/feat/abcnotation-play-button/site/docs/inovmicro-exao/i07-musique.md)). Utilise le synthétiseur WebAudio inclus dans `abcjs@^6.6.3` — **pas de dépendance supplémentaire**.

- Bouton « ▶ Écouter / ⏹ Arrêter » sur les portées non-`inline`.
- Mode `inline` (tableau des 7 notes) **inchangé** — pas de bouton.
- `AudioContext` créé dans le handler de clic (geste utilisateur requis par Chrome/Safari) et libéré au démontage.
- État `⏳ Chargement…` pendant le `prime` du synthé (chargement du soundfont).
- Auto-stop après `visualObj.getTotalTime()` + 200 ms de marge (CreateSynth n'expose pas d'event « ended »).
- `supportsAudio()` vérifié au render → bouton caché si WebAudio indisponible.

## Caveats à arbitrer après test en conditions réelles

- **Soundfont** : chargé depuis `paulrosen.github.io` (CDN par défaut d'abcjs). À self-host pour offline / RGPD.
- **Timbre** : piano par défaut. La STeaMi a un buzzer piezo qui sonne très différent → présenter comme une « pré-écoute » dans la fiche, ou basculer sur un soundfont synth carré plus proche.
- **Clic-pour-jouer** sur les portées inline du tableau des 7 notes : pas encore fait, UX à concevoir (clic direct sur la note plutôt que bouton séparé).
- Pas de curseur de progression pendant la lecture (à voir si utile).

## Type de changement

- [ ] Contenu — fiche, doc, texte
- [ ] Catalogue — entrée(s) dans `resources.ts` ou `projects.ts`
- [x] Code — composant React, page, type, CSS
- [ ] Configuration — config Docusaurus, CI, hooks
- [ ] Assets — images, PDFs, vidéos

## Test plan

- [x] `npm run site:typecheck` passe
- [x] `npm run site:build` passe (sans nouveau warning)
- [x] `npx prettier --check` passe sur les deux fichiers modifiés
- [ ] **Test manuel dans un navigateur** (à faire) : `npm run site:start` → ouvrir [`/ressources/inovmicro-exao/i07-musique`](http://localhost:3000/ressources/inovmicro-exao/i07-musique) → vérifier :
  - Le bouton « ▶ Écouter » apparaît sous la mélodie Tetris (et **pas** sous les mini-portées du tableau des 7 notes).
  - Clic → soundfont charge (latence de quelques centaines de ms à 1 s) → la mélodie joue au piano.
  - Re-clic pendant lecture → arrête le son.
  - Lecture jusqu'au bout → le bouton revient à « ▶ Écouter ».
  - Inspecter la console : pas d'erreur réseau bloquante (soundfont CDN).
- [ ] Vérifier dans le devtools Network le volume de données chargé pour le soundfont (info utile pour décider du self-hosting).

⚠️ Cette PR n'a **pas été testée dans un vrai navigateur** par l'agent (pas d'accès UI). Les checks de syntaxe et de build passent, mais la validation interactive reste à faire avant merge.

## Issues liées

Closes #158