### PR TITLE
docs(inovmicro-exao): refonte du gimmick Zelda (Title Theme, 12 mesures, depuis MIDI) + retrait Duck Tales

### DIFF
--- a/site/docs/inovmicro-exao/i07-musique.md
+++ b/site/docs/inovmicro-exao/i07-musique.md
@@ -415,25 +415,23 @@ d9 e3 f24 e6 d6 | c9 =d3 =e24 =g6 f6 |]`}
 </ABCNotation>
 
 ```python
-# Nouvelles constantes :
-FA_4 = 349
-SOL_4 = 392
+# Nouvelles constantes — uniquement les bémols et les octaves 5+
+# (les notes naturelles octaves 3/4 sont déjà définies en Étape 2).
 SOL_BEMOL_4 = 370
-LA_4 = 440
 LA_BEMOL_4 = 415
 SI_BEMOL_4 = 466
 DO_5 = 523
-RE_5 = 587
 RE_BEMOL_5 = 554
-MI_5 = 659
+RE_5 = 587
 MI_BEMOL_5 = 622
+MI_5 = 659
 FA_5 = 698
-SOL_5 = 784
 SOL_BEMOL_5 = 740
+SOL_5 = 784
 LA_BEMOL_5 = 831
 SI_BEMOL_5 = 932
 
-# Durées dérivées de CROCHE et NOIRE déjà définis plus haut :
+# Durées dérivées de CROCHE et NOIRE déjà définis en Étape 2 :
 # on les exprime relativement, pour rester cohérents si on change le tempo.
 DOUBLE_CROCHE = CROCHE // 2  # 125 ms
 CROCHE_POINTEE = CROCHE + DOUBLE_CROCHE  # 375 ms
@@ -441,32 +439,34 @@ NOIRE_POINTEE = NOIRE + CROCHE  # 750 ms
 BLANCHE = 2 * NOIRE  # 1000 ms
 BLANCHE_POINTEE = BLANCHE + NOIRE  # 1500 ms
 
-# Le motif suit le morceau original en Sib mineur. Les durées
-# 30/40/42 (rythmes nuancés du piano original) sont arrondies à la
-# blanche pointée pour rester jouable au buzzer.
+# Le motif suit le morceau original en Sib mineur. Les durées de
+# 2,5 et 3,5 temps (Sib et Lab tenus de l'intro) sont représentées
+# explicitement par BLANCHE + CROCHE et BLANCHE + NOIRE_POINTEE.
+# Les triolets de croches (mesures 7-8 — Solb/Lab à 1/3 de temps)
+# sont approximés par des doubles-croches sur le buzzer.
 partition = [
     # Mesures 1-4 — intro tenue
-    (SI_BEMOL_4, BLANCHE_POINTEE), (FA_4, NOIRE),                (SI_BEMOL_4, CROCHE),
-    (LA_BEMOL_4, DOUBLE_CROCHE),   (SOL_BEMOL_4, DOUBLE_CROCHE), (LA_BEMOL_4, BLANCHE_POINTEE),
-    (SI_BEMOL_4, BLANCHE_POINTEE), (SOL_BEMOL_4, NOIRE),         (SI_BEMOL_4, CROCHE),
-    (LA_4, DOUBLE_CROCHE),         (SOL_4, DOUBLE_CROCHE),       (LA_BEMOL_4, BLANCHE_POINTEE),
+    (SI_BEMOL_4, BLANCHE + CROCHE), (FA_4, NOIRE),                (SI_BEMOL_4, CROCHE),
+    (LA_BEMOL_4, DOUBLE_CROCHE),    (SOL_BEMOL_4, DOUBLE_CROCHE), (LA_BEMOL_4, BLANCHE + NOIRE_POINTEE),
+    (SI_BEMOL_4, BLANCHE + CROCHE), (SOL_BEMOL_4, NOIRE),         (SI_BEMOL_4, CROCHE),
+    (LA_4, DOUBLE_CROCHE),          (SOL_4, DOUBLE_CROCHE),       (LA_BEMOL_4, BLANCHE + NOIRE_POINTEE),
     # Mesures 5-6 — motif iconique : Sib martelé, saut Fa, montée chromatique vers Fa5 aigu
-    (SI_BEMOL_4, NOIRE),           (FA_4, NOIRE_POINTEE),        (SI_BEMOL_4, CROCHE_POINTEE),
-    (DO_5, DOUBLE_CROCHE),         (RE_5, DOUBLE_CROCHE),        (MI_BEMOL_5, DOUBLE_CROCHE),
-    (FA_5, CROCHE),                (SI_BEMOL_4, CROCHE_POINTEE),
-    (DO_5, DOUBLE_CROCHE),         (RE_5, DOUBLE_CROCHE),        (MI_BEMOL_5, DOUBLE_CROCHE),
+    (SI_BEMOL_4, NOIRE),            (FA_4, NOIRE_POINTEE),        (SI_BEMOL_4, CROCHE_POINTEE),
+    (DO_5, DOUBLE_CROCHE),          (RE_5, DOUBLE_CROCHE),        (MI_BEMOL_5, DOUBLE_CROCHE),
+    (FA_5, CROCHE),                 (SI_BEMOL_4, CROCHE_POINTEE),
+    (DO_5, DOUBLE_CROCHE),          (RE_5, DOUBLE_CROCHE),        (MI_BEMOL_5, DOUBLE_CROCHE),
     (FA_5, BLANCHE),
     # Mesures 7-8 — montée vers la culmination Sib5
-    (FA_5, BLANCHE_POINTEE),       (SOL_BEMOL_5, DOUBLE_CROCHE), (LA_BEMOL_5, DOUBLE_CROCHE),
-    (SI_BEMOL_5, BLANCHE_POINTEE), (LA_BEMOL_5, DOUBLE_CROCHE),  (SOL_BEMOL_5, DOUBLE_CROCHE),
+    (FA_5, BLANCHE_POINTEE),        (SOL_BEMOL_5, DOUBLE_CROCHE), (LA_BEMOL_5, DOUBLE_CROCHE),
+    (SI_BEMOL_5, BLANCHE_POINTEE),  (LA_BEMOL_5, DOUBLE_CROCHE),  (SOL_BEMOL_5, DOUBLE_CROCHE),
     # Mesures 9-12 — développement descendant qui résout sur Fa5
-    (LA_BEMOL_5, CROCHE_POINTEE),  (SOL_BEMOL_5, DOUBLE_CROCHE), (FA_5, BLANCHE_POINTEE),
-    (MI_BEMOL_5, CROCHE_POINTEE),  (FA_5, DOUBLE_CROCHE),        (SOL_BEMOL_5, BLANCHE),
-    (FA_5, CROCHE),                (MI_BEMOL_5, CROCHE),
-    (RE_BEMOL_5, CROCHE_POINTEE),  (MI_BEMOL_5, DOUBLE_CROCHE),  (FA_5, BLANCHE),
-    (MI_BEMOL_5, CROCHE),          (RE_BEMOL_5, CROCHE),
-    (DO_5, CROCHE_POINTEE),        (RE_5, DOUBLE_CROCHE),        (MI_5, BLANCHE),
-    (SOL_5, CROCHE),               (FA_5, CROCHE),
+    (LA_BEMOL_5, CROCHE_POINTEE),   (SOL_BEMOL_5, DOUBLE_CROCHE), (FA_5, BLANCHE_POINTEE),
+    (MI_BEMOL_5, CROCHE_POINTEE),   (FA_5, DOUBLE_CROCHE),        (SOL_BEMOL_5, BLANCHE),
+    (FA_5, CROCHE),                 (MI_BEMOL_5, CROCHE),
+    (RE_BEMOL_5, CROCHE_POINTEE),   (MI_BEMOL_5, DOUBLE_CROCHE),  (FA_5, BLANCHE),
+    (MI_BEMOL_5, CROCHE),           (RE_BEMOL_5, CROCHE),
+    (DO_5, CROCHE_POINTEE),         (RE_5, DOUBLE_CROCHE),        (MI_5, BLANCHE),
+    (SOL_5, CROCHE),                (FA_5, CROCHE),
 ]
 ```
 

--- a/site/docs/inovmicro-exao/i07-musique.md
+++ b/site/docs/inovmicro-exao/i07-musique.md
@@ -371,7 +371,7 @@ M:4/4
 L:1/16
 Q:1/4=130
 K:Bb
-B4 F6 B2 B c d e | f8 ^f ^g b6 |]`}
+B4 F6 B2 B c d e | f8 B8 | ^f2 ^g2 b12 |]`}
 </ABCNotation>
 
 ```python
@@ -387,21 +387,22 @@ SOL_DIESE_5 = 831
 SI_BEMOL_5 = 932
 
 DOUBLE_CROCHE = 125
-NOIRE_POINTEE = 750
 BLANCHE = 1000
+BLANCHE_POINTEE = 1500
 
 # Mesure 1 — motif iconique : Sib4 noire, saut grave vers Fa4 (noire
 # pointée), retour Sib4 (croche), montée chromatique Sib-Do-Ré-Mib en
-# doubles-croches. Mesure 2 — coda : Fa5 tenu (blanche), passage
-# chromatique Fa#5-Sol#5 (deux doubles-croches), culmination sur le
-# Sib5 aigu.
+# doubles-croches. Mesure 2 — culmination Fa5 tenu (blanche) puis
+# palier descendant Sib4 tenu (blanche). Mesure 3 — coda : passage
+# chromatique Fa#5-Sol#5 (croches), culmination sur le Sib5 aigu
+# (blanche pointée).
 partition = [
     (SI_BEMOL_4, NOIRE),         (FA_4, NOIRE_POINTEE),       (SI_BEMOL_4, CROCHE),
     (SI_BEMOL_4, DOUBLE_CROCHE), (DO_5, DOUBLE_CROCHE),
     (RE_5, DOUBLE_CROCHE),       (MI_BEMOL_5, DOUBLE_CROCHE),
-    (FA_5, BLANCHE),
-    (FA_DIESE_5, DOUBLE_CROCHE), (SOL_DIESE_5, DOUBLE_CROCHE),
-    (SI_BEMOL_5, NOIRE_POINTEE),
+    (FA_5, BLANCHE),             (SI_BEMOL_4, BLANCHE),
+    (FA_DIESE_5, CROCHE),        (SOL_DIESE_5, CROCHE),
+    (SI_BEMOL_5, BLANCHE_POINTEE),
 ]
 ```
 

--- a/site/docs/inovmicro-exao/i07-musique.md
+++ b/site/docs/inovmicro-exao/i07-musique.md
@@ -360,52 +360,6 @@ partition = [
 ]
 ```
 
-#### The Legend of Zelda, thème principal (Koji Kondo, 1986)
-
-L'appel à l'aventure du tout premier Zelda sur NES, transcrit ici dans sa phrase la plus reconnaissable : Sib martelé, saut grave vers Fa, retour Sib, montée chromatique **Sib-Do-Ré-Mib** qui culmine sur le Fa aigu, et coda ascendante vers le Sib aigu via Fa#-Sol#. Il introduit les **bémols** (`♭`) : un bémol baisse la note d'un demi-ton (`SI_BEMOL_4` est un demi-ton sous `SI_4`, `MI_BEMOL_5` est un demi-ton sous `MI_5`).
-
-<ABCNotation>
-{`X:1
-T:The Legend of Zelda - Main Theme
-M:4/4
-L:1/16
-Q:1/4=130
-K:Bb
-B4 F6 B2 B c d e | f8 B8 | ^f2 ^g2 b12 |]`}
-</ABCNotation>
-
-```python
-# Nouvelles constantes :
-FA_4 = 349
-SI_BEMOL_4 = 466
-DO_5 = 523
-RE_5 = 587
-MI_BEMOL_5 = 622
-FA_5 = 698
-FA_DIESE_5 = 740
-SOL_DIESE_5 = 831
-SI_BEMOL_5 = 932
-
-DOUBLE_CROCHE = 125
-BLANCHE = 1000
-BLANCHE_POINTEE = 1500
-
-# Mesure 1 — motif iconique : Sib4 noire, saut grave vers Fa4 (noire
-# pointée), retour Sib4 (croche), montée chromatique Sib-Do-Ré-Mib en
-# doubles-croches. Mesure 2 — culmination Fa5 tenu (blanche) puis
-# palier descendant Sib4 tenu (blanche). Mesure 3 — coda : passage
-# chromatique Fa#5-Sol#5 (croches), culmination sur le Sib5 aigu
-# (blanche pointée).
-partition = [
-    (SI_BEMOL_4, NOIRE),         (FA_4, NOIRE_POINTEE),       (SI_BEMOL_4, CROCHE),
-    (SI_BEMOL_4, DOUBLE_CROCHE), (DO_5, DOUBLE_CROCHE),
-    (RE_5, DOUBLE_CROCHE),       (MI_BEMOL_5, DOUBLE_CROCHE),
-    (FA_5, BLANCHE),             (SI_BEMOL_4, BLANCHE),
-    (FA_DIESE_5, CROCHE),        (SOL_DIESE_5, CROCHE),
-    (SI_BEMOL_5, BLANCHE_POINTEE),
-]
-```
-
 #### Kirby's Dream Land, Green Greens (Jun Ishikawa, 1992)
 
 Le thème principal du tout premier Kirby sur Game Boy : sautillant, joyeux, immédiatement reconnaissable. Sons rapides en croches.
@@ -437,6 +391,80 @@ partition = [
     (DO_5, CROCHE), (FA_5, CROCHE), (LA_5, NOIRE),
     (RE_5, CROCHE), (SOL_5, CROCHE), (SI_5, CROCHE), (SOL_5, CROCHE),
     (RE_5, CROCHE), (SOL_5, CROCHE), (SI_5, NOIRE),
+]
+```
+
+#### The Legend of Zelda, thème principal (Koji Kondo, 1986)
+
+L'écran-titre du tout premier Zelda sur NES, transcrit en 12 mesures suivant le morceau original (en Sib mineur). C'est le morceau le plus dense des quatre. On y trouve quatre temps : une **intro tenue** (Sib + Fa + Sib, puis Lab-Solb-Lab), le **motif iconique** (Sib martelé, saut grave vers Fa, montée chromatique Sib-Do-Ré-Mib culminant sur Fa5 aigu), une **culmination** sur Sib5 et un **développement descendant** Fa-Mib-Réb-Do qui résout sur Mi naturel-Sol-Fa.
+
+C'est aussi l'occasion d'introduire les **bémols** (`♭`) : un bémol baisse la note d'un demi-ton. Le Sib mineur en contient cinq (Sib, Mib, Lab, Solb, Réb), d'où la quantité de constantes ci-dessous.
+
+<ABCNotation>
+{`X:1
+T:The Legend of Zelda - Main Theme
+M:4/4
+L:1/48
+Q:1/4=130
+K:Bbm
+B30 F12 B6 | A3 G3 A42 | B30 G12 B6 | =A3 =G3 A42 |
+B12 F18 B9 c3 =d3 e3 | f6 B9 c3 =d3 e3 f24 |
+f40 g4 a4 | b40 a4 g4 |
+a9 g3 f36 | e9 f3 g24 f6 e6 |
+d9 e3 f24 e6 d6 | c9 =d3 =e24 =g6 f6 |]`}
+</ABCNotation>
+
+```python
+# Nouvelles constantes :
+FA_4 = 349
+SOL_4 = 392
+SOL_BEMOL_4 = 370
+LA_4 = 440
+LA_BEMOL_4 = 415
+SI_BEMOL_4 = 466
+DO_5 = 523
+RE_5 = 587
+RE_BEMOL_5 = 554
+MI_5 = 659
+MI_BEMOL_5 = 622
+FA_5 = 698
+SOL_5 = 784
+SOL_BEMOL_5 = 740
+LA_BEMOL_5 = 831
+SI_BEMOL_5 = 932
+
+DOUBLE_CROCHE = 125
+CROCHE_POINTEE = 375
+NOIRE_POINTEE = 750
+BLANCHE = 1000
+BLANCHE_POINTEE = 1500
+
+# Le motif suit le morceau original en Sib mineur. Les durées
+# 30/40/42 (rythmes nuancés du piano original) sont arrondies à la
+# blanche pointée pour rester jouable au buzzer.
+partition = [
+    # Mesures 1-4 — intro tenue
+    (SI_BEMOL_4, BLANCHE_POINTEE), (FA_4, NOIRE),                (SI_BEMOL_4, CROCHE),
+    (LA_BEMOL_4, DOUBLE_CROCHE),   (SOL_BEMOL_4, DOUBLE_CROCHE), (LA_BEMOL_4, BLANCHE_POINTEE),
+    (SI_BEMOL_4, BLANCHE_POINTEE), (SOL_BEMOL_4, NOIRE),         (SI_BEMOL_4, CROCHE),
+    (LA_4, DOUBLE_CROCHE),         (SOL_4, DOUBLE_CROCHE),       (LA_BEMOL_4, BLANCHE_POINTEE),
+    # Mesures 5-6 — motif iconique : Sib martelé, saut Fa, montée chromatique vers Fa5 aigu
+    (SI_BEMOL_4, NOIRE),           (FA_4, NOIRE_POINTEE),        (SI_BEMOL_4, CROCHE_POINTEE),
+    (DO_5, DOUBLE_CROCHE),         (RE_5, DOUBLE_CROCHE),        (MI_BEMOL_5, DOUBLE_CROCHE),
+    (FA_5, CROCHE),                (SI_BEMOL_4, CROCHE_POINTEE),
+    (DO_5, DOUBLE_CROCHE),         (RE_5, DOUBLE_CROCHE),        (MI_BEMOL_5, DOUBLE_CROCHE),
+    (FA_5, BLANCHE),
+    # Mesures 7-8 — montée vers la culmination Sib5
+    (FA_5, BLANCHE_POINTEE),       (SOL_BEMOL_5, DOUBLE_CROCHE), (LA_BEMOL_5, DOUBLE_CROCHE),
+    (SI_BEMOL_5, BLANCHE_POINTEE), (LA_BEMOL_5, DOUBLE_CROCHE),  (SOL_BEMOL_5, DOUBLE_CROCHE),
+    # Mesures 9-12 — développement descendant qui résout sur Fa5
+    (LA_BEMOL_5, CROCHE_POINTEE),  (SOL_BEMOL_5, DOUBLE_CROCHE), (FA_5, BLANCHE_POINTEE),
+    (MI_BEMOL_5, CROCHE_POINTEE),  (FA_5, DOUBLE_CROCHE),        (SOL_BEMOL_5, BLANCHE),
+    (FA_5, CROCHE),                (MI_BEMOL_5, CROCHE),
+    (RE_BEMOL_5, CROCHE_POINTEE),  (MI_BEMOL_5, DOUBLE_CROCHE),  (FA_5, BLANCHE),
+    (MI_BEMOL_5, CROCHE),          (RE_BEMOL_5, CROCHE),
+    (DO_5, CROCHE_POINTEE),        (RE_5, DOUBLE_CROCHE),        (MI_5, BLANCHE),
+    (SOL_5, CROCHE),               (FA_5, CROCHE),
 ]
 ```
 

--- a/site/docs/inovmicro-exao/i07-musique.md
+++ b/site/docs/inovmicro-exao/i07-musique.md
@@ -433,11 +433,13 @@ SOL_BEMOL_5 = 740
 LA_BEMOL_5 = 831
 SI_BEMOL_5 = 932
 
-DOUBLE_CROCHE = 125
-CROCHE_POINTEE = 375
-NOIRE_POINTEE = 750
-BLANCHE = 1000
-BLANCHE_POINTEE = 1500
+# Durées dérivées de CROCHE et NOIRE déjà définis plus haut :
+# on les exprime relativement, pour rester cohérents si on change le tempo.
+DOUBLE_CROCHE = CROCHE // 2  # 125 ms
+CROCHE_POINTEE = CROCHE + DOUBLE_CROCHE  # 375 ms
+NOIRE_POINTEE = NOIRE + CROCHE  # 750 ms
+BLANCHE = 2 * NOIRE  # 1000 ms
+BLANCHE_POINTEE = BLANCHE + NOIRE  # 1500 ms
 
 # Le motif suit le morceau original en Sib mineur. Les durées
 # 30/40/42 (rythmes nuancés du piano original) sont arrondies à la

--- a/site/docs/inovmicro-exao/i07-musique.md
+++ b/site/docs/inovmicro-exao/i07-musique.md
@@ -360,47 +360,52 @@ partition = [
 ]
 ```
 
-#### The Legend of Zelda, thème de la carte (Koji Kondo, 1986)
+#### The Legend of Zelda, thème principal (Koji Kondo, 1986)
 
-L'appel à l'aventure du tout premier Zelda sur NES. Il introduit les **bémols** (`♭`) : un bémol baisse la note d'un demi-ton (`SI_BEMOL_4` est un demi-ton sous `SI_4`).
+L'appel à l'aventure du tout premier Zelda sur NES, transcrit ici dans sa phrase la plus reconnaissable : Sib tenu, saut vers Fa, puis montée chromatique **Sib-Do-Ré-Mib** qui culmine sur le Fa aigu. Il introduit les **bémols** (`♭`) : un bémol baisse la note d'un demi-ton (`SI_BEMOL_4` est un demi-ton sous `SI_4`, `MI_BEMOL_5` est un demi-ton sous `MI_5`).
 
 <ABCNotation>
 {`X:1
-T:The Legend of Zelda - Overworld Theme
+T:The Legend of Zelda - Main Theme
 M:4/4
-L:1/8
-Q:1/4=120
+L:1/16
+Q:1/4=130
 K:Bb
-B2 f2 B2 F2 | B2 f2 B4 | F G A B f4 | _e2 d2 _e2 f2 |
-B2 f2 B2 F2 | B2 f2 B4 | F G A B f4 | B8 |]`}
+B4 F6 B2 B c d e | f2 B2 B c d e f8 | B4 F6 B2 B c d e | f2 B2 B c d e f8 |]`}
 </ABCNotation>
 
 ```python
 # Nouvelles constantes :
 FA_4 = 349
-SOL_4 = 392
-LA_4 = 440
 SI_BEMOL_4 = 466
+DO_5 = 523
 RE_5 = 587
 MI_BEMOL_5 = 622
 FA_5 = 698
+
+DOUBLE_CROCHE = 125
+NOIRE_POINTEE = 750
 BLANCHE = 1000
 
+# Le motif tourne deux fois : Sib4 tenu, saut grave vers Fa4, retour
+# Sib4, montée chromatique Sib-Do-Ré-Mib en doubles-croches, descente
+# sur le Fa5 aigu, nouvelle montée chromatique, conclusion sur Fa5.
 partition = [
-    # Phrase principale : Sib martelé puis montée en croches
-    (SI_BEMOL_4, NOIRE), (FA_5, NOIRE),   (SI_BEMOL_4, NOIRE), (FA_4, NOIRE),
-    (SI_BEMOL_4, NOIRE), (FA_5, NOIRE),   (SI_BEMOL_4, BLANCHE),
-    (FA_4, CROCHE),      (SOL_4, CROCHE), (LA_4, CROCHE),      (SI_BEMOL_4, CROCHE),
+    (SI_BEMOL_4, NOIRE),         (FA_4, NOIRE_POINTEE),       (SI_BEMOL_4, CROCHE),
+    (SI_BEMOL_4, DOUBLE_CROCHE), (DO_5, DOUBLE_CROCHE),
+    (RE_5, DOUBLE_CROCHE),       (MI_BEMOL_5, DOUBLE_CROCHE),
+    (FA_5, CROCHE),              (SI_BEMOL_4, CROCHE),
+    (SI_BEMOL_4, DOUBLE_CROCHE), (DO_5, DOUBLE_CROCHE),
+    (RE_5, DOUBLE_CROCHE),       (MI_BEMOL_5, DOUBLE_CROCHE),
     (FA_5, BLANCHE),
-    # Pont : motif ondulant Mib-Ré-Mib-Fa
-    (MI_BEMOL_5, NOIRE), (RE_5, NOIRE),   (MI_BEMOL_5, NOIRE), (FA_5, NOIRE),
-    # Reprise de la phrase principale
-    (SI_BEMOL_4, NOIRE), (FA_5, NOIRE),   (SI_BEMOL_4, NOIRE), (FA_4, NOIRE),
-    (SI_BEMOL_4, NOIRE), (FA_5, NOIRE),   (SI_BEMOL_4, BLANCHE),
-    (FA_4, CROCHE),      (SOL_4, CROCHE), (LA_4, CROCHE),      (SI_BEMOL_4, CROCHE),
+    # Répétition
+    (SI_BEMOL_4, NOIRE),         (FA_4, NOIRE_POINTEE),       (SI_BEMOL_4, CROCHE),
+    (SI_BEMOL_4, DOUBLE_CROCHE), (DO_5, DOUBLE_CROCHE),
+    (RE_5, DOUBLE_CROCHE),       (MI_BEMOL_5, DOUBLE_CROCHE),
+    (FA_5, CROCHE),              (SI_BEMOL_4, CROCHE),
+    (SI_BEMOL_4, DOUBLE_CROCHE), (DO_5, DOUBLE_CROCHE),
+    (RE_5, DOUBLE_CROCHE),       (MI_BEMOL_5, DOUBLE_CROCHE),
     (FA_5, BLANCHE),
-    # Conclusion sur Sib tenu
-    (SI_BEMOL_4, BLANCHE),
 ]
 ```
 

--- a/site/docs/inovmicro-exao/i07-musique.md
+++ b/site/docs/inovmicro-exao/i07-musique.md
@@ -296,7 +296,7 @@ Représenter une mélodie comme une **liste de tuples** est un choix courant en 
 
 ### 1. Changer de mélodie
 
-Le plus simple : remplacer le contenu de la liste `partition` par d'autres notes. Voici cinq gimmicks emblématiques de l'âge d'or du jeu vidéo 8 bits, à copier-coller à la place de notre Korobeïniki. Pensez à ajouter en haut du fichier les constantes de notes qui manquent (notre code n'en définit que jusqu'à `LA_4` pour l'instant).
+Le plus simple : remplacer le contenu de la liste `partition` par d'autres notes. Voici quatre gimmicks emblématiques de l'âge d'or du jeu vidéo 8 bits, à copier-coller à la place de notre Korobeïniki. Pensez à ajouter en haut du fichier les constantes de notes qui manquent (notre code n'en définit que jusqu'à `LA_4` pour l'instant).
 
 #### Super Mario Bros, Ground Theme (Koji Kondo, 1985)
 
@@ -371,7 +371,8 @@ M:4/4
 L:1/8
 Q:1/4=120
 K:Bb
-B2 f2 B2 F2 | B2 f2 B4 | F G A B f4 |]`}
+B2 f2 B2 F2 | B2 f2 B4 | F G A B f4 | _e2 d2 _e2 f2 |
+B2 f2 B2 F2 | B2 f2 B4 | F G A B f4 | B8 |]`}
 </ABCNotation>
 
 ```python
@@ -380,13 +381,26 @@ FA_4 = 349
 SOL_4 = 392
 LA_4 = 440
 SI_BEMOL_4 = 466
+RE_5 = 587
+MI_BEMOL_5 = 622
 FA_5 = 698
+BLANCHE = 1000
 
 partition = [
-    (SI_BEMOL_4, NOIRE), (FA_5, NOIRE),  (SI_BEMOL_4, NOIRE), (FA_4, NOIRE),
-    (SI_BEMOL_4, NOIRE), (FA_5, NOIRE),  (SI_BEMOL_4, BLANCHE),
-    (FA_4, CROCHE),      (SOL_4, CROCHE), (LA_4, CROCHE),     (SI_BEMOL_4, CROCHE),
+    # Phrase principale : Sib martelé puis montée en croches
+    (SI_BEMOL_4, NOIRE), (FA_5, NOIRE),   (SI_BEMOL_4, NOIRE), (FA_4, NOIRE),
+    (SI_BEMOL_4, NOIRE), (FA_5, NOIRE),   (SI_BEMOL_4, BLANCHE),
+    (FA_4, CROCHE),      (SOL_4, CROCHE), (LA_4, CROCHE),      (SI_BEMOL_4, CROCHE),
     (FA_5, BLANCHE),
+    # Pont : motif ondulant Mib-Ré-Mib-Fa
+    (MI_BEMOL_5, NOIRE), (RE_5, NOIRE),   (MI_BEMOL_5, NOIRE), (FA_5, NOIRE),
+    # Reprise de la phrase principale
+    (SI_BEMOL_4, NOIRE), (FA_5, NOIRE),   (SI_BEMOL_4, NOIRE), (FA_4, NOIRE),
+    (SI_BEMOL_4, NOIRE), (FA_5, NOIRE),   (SI_BEMOL_4, BLANCHE),
+    (FA_4, CROCHE),      (SOL_4, CROCHE), (LA_4, CROCHE),      (SI_BEMOL_4, CROCHE),
+    (FA_5, BLANCHE),
+    # Conclusion sur Sib tenu
+    (SI_BEMOL_4, BLANCHE),
 ]
 ```
 
@@ -421,41 +435,6 @@ partition = [
     (DO_5, CROCHE), (FA_5, CROCHE), (LA_5, NOIRE),
     (RE_5, CROCHE), (SOL_5, CROCHE), (SI_5, CROCHE), (SOL_5, CROCHE),
     (RE_5, CROCHE), (SOL_5, CROCHE), (SI_5, NOIRE),
-]
-```
-
-#### DuckTales, Moon Theme (Hiroshige Tonomura, 1989)
-
-Souvent cité parmi les plus belles musiques de la NES. Voici les premières mesures du motif principal, celles qui s'enchaînent dès l'arrivée sur la Lune.
-
-<ABCNotation>
-{`X:1
-T:DuckTales - Moon Theme
-M:4/4
-L:1/8
-Q:1/4=130
-K:C
-a2 a g ^f2 e d | e2 ^f g a2 b c' | d'4 z4 |]`}
-</ABCNotation>
-
-```python
-# Nouvelles constantes :
-RE_5 = 587
-MI_5 = 659
-FA_5 = 698
-FA_DIESE_5 = 740
-SOL_5 = 784
-LA_5 = 880
-SI_5 = 988
-DO_6 = 1047
-RE_6 = 1175
-
-partition = [
-    (LA_5, NOIRE),  (LA_5, CROCHE),       (SOL_5, CROCHE),
-    (FA_DIESE_5, NOIRE), (MI_5, CROCHE),  (RE_5, CROCHE),
-    (MI_5, NOIRE),  (FA_DIESE_5, CROCHE), (SOL_5, CROCHE),
-    (LA_5, NOIRE),  (SI_5, CROCHE),       (DO_6, CROCHE),
-    (RE_6, BLANCHE),
 ]
 ```
 

--- a/site/docs/inovmicro-exao/i07-musique.md
+++ b/site/docs/inovmicro-exao/i07-musique.md
@@ -362,7 +362,7 @@ partition = [
 
 #### The Legend of Zelda, thème principal (Koji Kondo, 1986)
 
-L'appel à l'aventure du tout premier Zelda sur NES, transcrit ici dans sa phrase la plus reconnaissable : Sib tenu, saut vers Fa, puis montée chromatique **Sib-Do-Ré-Mib** qui culmine sur le Fa aigu. Il introduit les **bémols** (`♭`) : un bémol baisse la note d'un demi-ton (`SI_BEMOL_4` est un demi-ton sous `SI_4`, `MI_BEMOL_5` est un demi-ton sous `MI_5`).
+L'appel à l'aventure du tout premier Zelda sur NES, transcrit ici dans sa phrase la plus reconnaissable : Sib tenu, saut vers Fa, puis montée chromatique **Sib-Do-Ré-Mib** qui culmine sur le Fa aigu, et coda ascendante vers le Sib aigu via Fa#-Sol#. Il introduit les **bémols** (`♭`) : un bémol baisse la note d'un demi-ton (`SI_BEMOL_4` est un demi-ton sous `SI_4`, `MI_BEMOL_5` est un demi-ton sous `MI_5`).
 
 <ABCNotation>
 {`X:1
@@ -371,7 +371,7 @@ M:4/4
 L:1/16
 Q:1/4=130
 K:Bb
-B4 F6 B2 B c d e | f2 B2 B c d e f8 | B4 F6 B2 B c d e | f2 B2 B c d e f8 |]`}
+B4 F6 B2 B c d e | f2 B2 B c d e f8 | f8 ^f ^g b6 |]`}
 </ABCNotation>
 
 ```python
@@ -382,14 +382,19 @@ DO_5 = 523
 RE_5 = 587
 MI_BEMOL_5 = 622
 FA_5 = 698
+FA_DIESE_5 = 740
+SOL_DIESE_5 = 831
+SI_BEMOL_5 = 932
 
 DOUBLE_CROCHE = 125
 NOIRE_POINTEE = 750
 BLANCHE = 1000
 
-# Le motif tourne deux fois : Sib4 tenu, saut grave vers Fa4, retour
-# Sib4, montée chromatique Sib-Do-Ré-Mib en doubles-croches, descente
-# sur le Fa5 aigu, nouvelle montée chromatique, conclusion sur Fa5.
+# Mesure 1 — motif iconique : Sib4 noire, saut grave vers Fa4 (noire
+# pointée), retour Sib4, montée chromatique Sib-Do-Ré-Mib en doubles-
+# croches. Mesure 2 — descente sur le Fa5 aigu, nouvelle montée
+# chromatique, Fa5 tenu en blanche. Mesure 3 — coda : Fa5 tenu, deux
+# doubles-croches Fa#-Sol# en passage, et culmination sur le Sib aigu.
 partition = [
     (SI_BEMOL_4, NOIRE),         (FA_4, NOIRE_POINTEE),       (SI_BEMOL_4, CROCHE),
     (SI_BEMOL_4, DOUBLE_CROCHE), (DO_5, DOUBLE_CROCHE),
@@ -398,14 +403,8 @@ partition = [
     (SI_BEMOL_4, DOUBLE_CROCHE), (DO_5, DOUBLE_CROCHE),
     (RE_5, DOUBLE_CROCHE),       (MI_BEMOL_5, DOUBLE_CROCHE),
     (FA_5, BLANCHE),
-    # Répétition
-    (SI_BEMOL_4, NOIRE),         (FA_4, NOIRE_POINTEE),       (SI_BEMOL_4, CROCHE),
-    (SI_BEMOL_4, DOUBLE_CROCHE), (DO_5, DOUBLE_CROCHE),
-    (RE_5, DOUBLE_CROCHE),       (MI_BEMOL_5, DOUBLE_CROCHE),
-    (FA_5, CROCHE),              (SI_BEMOL_4, CROCHE),
-    (SI_BEMOL_4, DOUBLE_CROCHE), (DO_5, DOUBLE_CROCHE),
-    (RE_5, DOUBLE_CROCHE),       (MI_BEMOL_5, DOUBLE_CROCHE),
-    (FA_5, BLANCHE),
+    (FA_DIESE_5, DOUBLE_CROCHE), (SOL_DIESE_5, DOUBLE_CROCHE),
+    (SI_BEMOL_5, NOIRE_POINTEE),
 ]
 ```
 

--- a/site/docs/inovmicro-exao/i07-musique.md
+++ b/site/docs/inovmicro-exao/i07-musique.md
@@ -362,7 +362,7 @@ partition = [
 
 #### The Legend of Zelda, thème principal (Koji Kondo, 1986)
 
-L'appel à l'aventure du tout premier Zelda sur NES, transcrit ici dans sa phrase la plus reconnaissable : Sib tenu, saut vers Fa, puis montée chromatique **Sib-Do-Ré-Mib** qui culmine sur le Fa aigu, et coda ascendante vers le Sib aigu via Fa#-Sol#. Il introduit les **bémols** (`♭`) : un bémol baisse la note d'un demi-ton (`SI_BEMOL_4` est un demi-ton sous `SI_4`, `MI_BEMOL_5` est un demi-ton sous `MI_5`).
+L'appel à l'aventure du tout premier Zelda sur NES, transcrit ici dans sa phrase la plus reconnaissable : Sib martelé, saut grave vers Fa, retour Sib, montée chromatique **Sib-Do-Ré-Mib** qui culmine sur le Fa aigu, et coda ascendante vers le Sib aigu via Fa#-Sol#. Il introduit les **bémols** (`♭`) : un bémol baisse la note d'un demi-ton (`SI_BEMOL_4` est un demi-ton sous `SI_4`, `MI_BEMOL_5` est un demi-ton sous `MI_5`).
 
 <ABCNotation>
 {`X:1
@@ -371,7 +371,7 @@ M:4/4
 L:1/16
 Q:1/4=130
 K:Bb
-B4 F6 B2 B c d e | f2 B2 B c d e f8 | f8 ^f ^g b6 |]`}
+B4 F6 B2 B c d e | f8 ^f ^g b6 |]`}
 </ABCNotation>
 
 ```python
@@ -391,15 +391,12 @@ NOIRE_POINTEE = 750
 BLANCHE = 1000
 
 # Mesure 1 — motif iconique : Sib4 noire, saut grave vers Fa4 (noire
-# pointée), retour Sib4, montée chromatique Sib-Do-Ré-Mib en doubles-
-# croches. Mesure 2 — descente sur le Fa5 aigu, nouvelle montée
-# chromatique, Fa5 tenu en blanche. Mesure 3 — coda : Fa5 tenu, deux
-# doubles-croches Fa#-Sol# en passage, et culmination sur le Sib aigu.
+# pointée), retour Sib4 (croche), montée chromatique Sib-Do-Ré-Mib en
+# doubles-croches. Mesure 2 — coda : Fa5 tenu (blanche), passage
+# chromatique Fa#5-Sol#5 (deux doubles-croches), culmination sur le
+# Sib5 aigu.
 partition = [
     (SI_BEMOL_4, NOIRE),         (FA_4, NOIRE_POINTEE),       (SI_BEMOL_4, CROCHE),
-    (SI_BEMOL_4, DOUBLE_CROCHE), (DO_5, DOUBLE_CROCHE),
-    (RE_5, DOUBLE_CROCHE),       (MI_BEMOL_5, DOUBLE_CROCHE),
-    (FA_5, CROCHE),              (SI_BEMOL_4, CROCHE),
     (SI_BEMOL_4, DOUBLE_CROCHE), (DO_5, DOUBLE_CROCHE),
     (RE_5, DOUBLE_CROCHE),       (MI_BEMOL_5, DOUBLE_CROCHE),
     (FA_5, BLANCHE),


### PR DESCRIPTION
## Résumé

Section « Aller plus loin → Changer de mélodie » de [`i07-musique.md`](../blob/docs/zelda-extend-ducktales-remove/site/docs/inovmicro-exao/i07-musique.md).

- **Refonte du gimmick Zelda** : on bascule de l'« Overworld Theme » (3 mesures, version courte initiale) vers le **Title Theme** (12 mesures), seul disponible en MIDI + PDF NinSheetMusic fournis par l'utilisateur pendant la revue. Transcription validée à l'oreille via le bouton « ▶ Écouter » de PR #159. Le motif iconique original répète sa phrase 3 fois, ce qui bégaie sur le buzzer mono-voix — on saute les répétitions et on enchaîne intro tenue → motif iconique → culmination Sib5 → développement descendant.
- **Duck Tales Moon Theme retiré** : musique superbe mais trop niche pour des collégien·nes. Les autres gimmicks (Mario, Pac-Man, Kirby) restent.
- **Réordonnement** : Zelda passe en dernier (le plus dense des 4 gimmicks par complexité croissante : Mario → Pac-Man → Kirby → Zelda).
- **Texte d'intro** : « cinq gimmicks » → « quatre gimmicks ».

## Détails techniques

- Bloc ABC en `K:Bbm L:1/48`, fidèle au MIDI source.
- Bloc Python avec les nouvelles constantes pour les bémols du Sib mineur (Solb, Lab, Réb) et le 5e octave.
- Durées dérivées de `CROCHE` et `NOIRE` déjà définies en Étape 2 (revue Copilot : éviter les nombres magiques en ms).
- Durées 2,5 et 3,5 temps représentées explicitement par `BLANCHE + CROCHE` et `BLANCHE + NOIRE_POINTEE` (revue Copilot : pas d'arrondi trop agressif).
- Triolets de croches (mesures 7-8) approximés en doubles-croches sur le buzzer (compromis documenté en commentaire).

## Type de changement

- [x] Contenu — fiche, doc, texte
- [ ] Catalogue — entrée(s) dans `resources.ts` ou `projects.ts`
- [ ] Code — composant React, page, type, CSS
- [ ] Configuration — config Docusaurus, CI, hooks
- [ ] Assets — images, PDFs, vidéos

## Test plan

- [x] `npm run site:build` passe sans nouveau warning.
- [x] `npm run lint:md`, `format:check`, `lint:spell` passent (validés via le hook pre-commit).
- [x] Test audio à l'oreille via le bouton « Écouter » de PR #159 (mergée) sur les 12 mesures.
- [x] Revue Copilot adressée : durées sans nombres magiques, constantes non-dupliquées, fidélité rythmique des mesures 1-4, texte/description alignés sur la version livrée (Title Theme).

## Issues liées

Closes #160