### PR TITLE
feat(code): rend les catégories du breadcrumb cliquables vers le catalogue filtré

### DIFF
--- a/site/src/data/categories.ts
+++ b/site/src/data/categories.ts
@@ -1,0 +1,34 @@
+// Module léger isolé pour éviter de tirer tout le tableau `resources`
+// (volumineux) dans les bundles qui n'ont besoin que des libellés
+// pédagogiques — typiquement le swizzle DocBreadcrumbs qui est rendu
+// sur toutes les pages docs.
+//
+// `resources.ts` réexporte ces deux symboles pour la rétro-compatibilité
+// des autres imports (catalogue.tsx, sidebars.ts…).
+
+export type Category =
+  | 'programmation'
+  | 'exploration-scientifique'
+  | 'theatre-sciences'
+  | 'sequences-debranchees'
+  | 'robotique-ludique'
+  | 'citoyennete-territoire'
+  | 'ia-esprit-critique'
+  | 'makers-fabrication'
+  | 'arts-creativite'
+  | 'environnement-nature'
+  | 'animation-jeunesse';
+
+export const categoryLabels: Record<Category, string> = {
+  programmation: '🔌 Programmation',
+  'exploration-scientifique': '🔬 Exploration scientifique',
+  'theatre-sciences': '🎭 Théâtre et sciences',
+  'sequences-debranchees': '📝 Séquences débranchées',
+  'robotique-ludique': '🤖 Robotique ludique',
+  'citoyennete-territoire': '🏙️ Citoyenneté et territoire',
+  'ia-esprit-critique': '🧠 IA et esprit critique',
+  'makers-fabrication': '🛠️ Makers et fabrication',
+  'arts-creativite': '🎨 Arts et créativité',
+  'environnement-nature': '🌱 Environnement et nature',
+  'animation-jeunesse': "🎯 Actions d'animation jeunesse",
+};

--- a/site/src/data/resources.ts
+++ b/site/src/data/resources.ts
@@ -61,18 +61,13 @@ export type Project =
   | 'inovmicro-exao'
   | 'projets-du-lab';
 
-export type Category =
-  | 'programmation'
-  | 'exploration-scientifique'
-  | 'theatre-sciences'
-  | 'sequences-debranchees'
-  | 'robotique-ludique'
-  | 'citoyennete-territoire'
-  | 'ia-esprit-critique'
-  | 'makers-fabrication'
-  | 'arts-creativite'
-  | 'environnement-nature'
-  | 'animation-jeunesse';
+// Category + categoryLabels vivent dans ./categories.ts pour que les
+// modules qui n'ont besoin que des libellés (DocBreadcrumbs) ne tirent
+// pas tout le tableau `resources` dans leur bundle. On les importe
+// pour l'usage local + on les réexporte pour ne pas casser les
+// imports existants depuis ce module.
+import { type Category, categoryLabels } from './categories';
+export { type Category, categoryLabels };
 
 export interface Resource {
   id: string;
@@ -4478,20 +4473,6 @@ export const projectLabels: Record<Project, string> = {
   magnetics: 'Magnetics',
   'inovmicro-exao': 'I-Novmicro #2',
   'projets-du-lab': 'Projets du LAB',
-};
-
-export const categoryLabels: Record<Category, string> = {
-  programmation: '🔌 Programmation',
-  'exploration-scientifique': '🔬 Exploration scientifique',
-  'theatre-sciences': '🎭 Théâtre et sciences',
-  'sequences-debranchees': '📝 Séquences débranchées',
-  'robotique-ludique': '🤖 Robotique ludique',
-  'citoyennete-territoire': '🏙️ Citoyenneté et territoire',
-  'ia-esprit-critique': '🧠 IA et esprit critique',
-  'makers-fabrication': '🛠️ Makers et fabrication',
-  'arts-creativite': '🎨 Arts et créativité',
-  'environnement-nature': '🌱 Environnement et nature',
-  'animation-jeunesse': "🎯 Actions d'animation jeunesse",
 };
 
 export const disciplineLabels: Record<Discipline, string> = {

--- a/site/src/theme/DocBreadcrumbs/index.tsx
+++ b/site/src/theme/DocBreadcrumbs/index.tsx
@@ -1,0 +1,124 @@
+/**
+ * Swizzle de DocBreadcrumbs (eject) — copie du composant officiel
+ * Docusaurus avec un seul changement : les catégories sans page
+ * d'index reçoivent automatiquement un href vers
+ * /catalogue?cat=KEY si leur label correspond à une catégorie
+ * pédagogique connue (cf. categoryLabels). Cela rend la
+ * catégorie cliquable et amène l'utilisateur vers la liste
+ * préfiltrée des fiches.
+ *
+ * Source d'origine :
+ *   node_modules/@docusaurus/theme-classic/src/theme/DocBreadcrumbs/index.tsx
+ */
+import React, { type ReactNode } from 'react';
+import clsx from 'clsx';
+import { ThemeClassNames } from '@docusaurus/theme-common';
+import { useSidebarBreadcrumbs } from '@docusaurus/plugin-content-docs/client';
+import { useHomePageRoute } from '@docusaurus/theme-common/internal';
+import useBaseUrl from '@docusaurus/useBaseUrl';
+import Link from '@docusaurus/Link';
+import { translate } from '@docusaurus/Translate';
+import HomeBreadcrumbItem from '@theme/DocBreadcrumbs/Items/Home';
+import DocBreadcrumbsStructuredData from '@theme/DocBreadcrumbs/StructuredData';
+
+import { categoryLabels, type Category } from '../../data/resources';
+import styles from './styles.module.css';
+
+// Map inverse : label affiché → clé Category. Permet de retrouver
+// la clé à partir du label rencontré dans le breadcrumb.
+const LABEL_TO_CATEGORY: Record<string, Category> = Object.fromEntries(
+  (Object.entries(categoryLabels) as [Category, string][]).map(([k, v]) => [v, k]),
+);
+
+function BreadcrumbsItemLink({
+  children,
+  href,
+  isLast,
+}: {
+  children: ReactNode;
+  href: string | undefined;
+  isLast: boolean;
+}): ReactNode {
+  const className = 'breadcrumbs__link';
+  if (isLast) {
+    return <span className={className}>{children}</span>;
+  }
+  return href ? (
+    <Link className={className} href={href}>
+      <span>{children}</span>
+    </Link>
+  ) : (
+    <span className={className}>{children}</span>
+  );
+}
+
+function BreadcrumbsItem({
+  children,
+  active,
+}: {
+  children: ReactNode;
+  active?: boolean;
+}): ReactNode {
+  return (
+    <li
+      className={clsx('breadcrumbs__item', {
+        'breadcrumbs__item--active': active,
+      })}
+    >
+      {children}
+    </li>
+  );
+}
+
+export default function DocBreadcrumbs(): ReactNode {
+  const breadcrumbs = useSidebarBreadcrumbs();
+  const homePageRoute = useHomePageRoute();
+  // useBaseUrl prend en compte le sous-chemin éventuel (baseUrl
+  // de docusaurus.config.ts) — important pour le déploiement GH Pages.
+  const catalogueBase = useBaseUrl('/catalogue');
+
+  if (!breadcrumbs) {
+    return null;
+  }
+
+  return (
+    <>
+      <DocBreadcrumbsStructuredData breadcrumbs={breadcrumbs} />
+      <nav
+        className={clsx(ThemeClassNames.docs.docBreadcrumbs, styles.breadcrumbsContainer)}
+        aria-label={translate({
+          id: 'theme.docs.breadcrumbs.navAriaLabel',
+          message: 'Breadcrumbs',
+          description: 'The ARIA label for the breadcrumbs',
+        })}
+      >
+        <ul className="breadcrumbs">
+          {homePageRoute && <HomeBreadcrumbItem />}
+          {breadcrumbs.map((item, idx) => {
+            const isLast = idx === breadcrumbs.length - 1;
+            let href: string | undefined =
+              item.type === 'category' && item.linkUnlisted ? undefined : item.href;
+
+            // Pour les catégories sans href (= pas de page d'index)
+            // dont le label correspond à une catégorie pédagogique
+            // connue, on génère un lien vers le catalogue préfiltré.
+            if (!href && item.type === 'category') {
+              const catKey = LABEL_TO_CATEGORY[item.label];
+              if (catKey) {
+                href = `${catalogueBase}?cat=${catKey}`;
+              }
+            }
+
+            return (
+              <BreadcrumbsItem key={idx} active={isLast}>
+                <BreadcrumbsItemLink href={href} isLast={isLast}>
+                  {item.label}
+                </BreadcrumbsItemLink>
+              </BreadcrumbsItem>
+            );
+          })}
+        </ul>
+      </nav>
+    </>
+  );
+}

--- a/site/src/theme/DocBreadcrumbs/index.tsx
+++ b/site/src/theme/DocBreadcrumbs/index.tsx
@@ -21,7 +21,10 @@ import { translate } from '@docusaurus/Translate';
 import HomeBreadcrumbItem from '@theme/DocBreadcrumbs/Items/Home';
 import DocBreadcrumbsStructuredData from '@theme/DocBreadcrumbs/StructuredData';
 
-import { categoryLabels, type Category } from '../../data/resources';
+// Import depuis le module léger `categories.ts` plutôt que `resources.ts`
+// pour ne pas embarquer le tableau `resources` (~4500 lignes) dans le
+// bundle des pages docs où DocBreadcrumbs est rendu.
+import { categoryLabels, type Category } from '../../data/categories';
 import styles from './styles.module.css';
 
 // Map inverse : label affiché → clé Category. Permet de retrouver
@@ -96,13 +99,15 @@ export default function DocBreadcrumbs(): ReactNode {
           {homePageRoute && <HomeBreadcrumbItem />}
           {breadcrumbs.map((item, idx) => {
             const isLast = idx === breadcrumbs.length - 1;
-            let href: string | undefined =
-              item.type === 'category' && item.linkUnlisted ? undefined : item.href;
+            const isUnlisted = item.type === 'category' && item.linkUnlisted;
+            let href: string | undefined = isUnlisted ? undefined : item.href;
 
             // Pour les catégories sans href (= pas de page d'index)
             // dont le label correspond à une catégorie pédagogique
             // connue, on génère un lien vers le catalogue préfiltré.
-            if (!href && item.type === 'category') {
+            // On exclut les `linkUnlisted` : Docusaurus a volontairement
+            // retiré leur lien, on respecte cette intention.
+            if (!href && !isUnlisted && item.type === 'category') {
               const catKey = LABEL_TO_CATEGORY[item.label];
               if (catKey) {
                 href = `${catalogueBase}?cat=${catKey}`;

--- a/site/src/theme/DocBreadcrumbs/styles.module.css
+++ b/site/src/theme/DocBreadcrumbs/styles.module.css
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+.breadcrumbsContainer {
+  --ifm-breadcrumb-size-multiplier: 0.8;
+  margin-bottom: 0.8rem;
+}


### PR DESCRIPTION
## Résumé

Sur une fiche d'activité, le fil d'Ariane affiche « 🏠 > 🔌 Programmation > Faire clignoter une LED ». La catégorie pédagogique au milieu n'a pas de page d'index, elle n'était donc pas cliquable.

Suite à la PR #170 (filtres catalogue dans l'URL), on peut maintenant la rendre cliquable en pointant vers le catalogue préfiltré. Cliquer sur « 🔌 Programmation » → [`/catalogue?cat=programmation`](https://wiki.labaixbidouille.com/catalogue?cat=programmation).

## Implémentation

Swizzle de `DocBreadcrumbs` (eject) qui copie le composant officiel Docusaurus avec **un seul changement** : pour chaque item de type `category` sans href, si le label correspond à `categoryLabels[k]`, on génère un `href = useBaseUrl('/catalogue') + '?cat=' + k`.

- Map inverse `label → catKey` construit une fois au module load.
- `useBaseUrl` pour respecter le `baseUrl` Docusaurus (sous-chemin GH Pages).
- Catégories inconnues (= label sans match dans `categoryLabels`) restent non cliquables comme avant — pas de régression.

## Type de changement

- [ ] Contenu — fiche, doc, texte
- [ ] Catalogue — entrée(s) dans `resources.ts` ou `projects.ts`
- [x] Code — composant React, page, type, CSS
- [ ] Configuration — config Docusaurus, CI, hooks
- [ ] Assets — images, PDFs, vidéos

## Test plan

- [x] `npm run site:typecheck` passe.
- [x] `npm run site:build` passe sans nouveau warning.
- [x] `npx prettier --check` passe.
- [ ] **Test manuel dans un navigateur** : ouvrir une fiche, cliquer sur le breadcrumb de catégorie → arrive sur le catalogue avec le bon filtre coché.

## Issues liées

Closes #173
Refs #170 (filtres catalogue dans l'URL)