### PR TITLE
fix(inovmicro-exao): corriger les callouts cassés

### DIFF
--- a/site/docs/inovmicro-exao/depannage.md
+++ b/site/docs/inovmicro-exao/depannage.md
@@ -81,7 +81,7 @@ Le port apparaît sous la forme `/dev/cu.usbmodemXXXX` (le suffixe est généré
 2. Glisser ce fichier sur le disque `STEAMI` qui apparaît à l'ordinateur.
 3. Attendre que la LED de statut arrête de clignoter et que la carte redémarre (5 à 15 secondes).
 
-:::warning Attention au bon fichier
+:::warning[Attention au bon fichier]
 
 Le dépôt GitHub `micropython-steami-lib` propose aussi un fichier `steami-daplink-firmware-...hex` qui n'a rien à voir avec MicroPython (c'est le logiciel de l'interface de programmation, pas celui qui exécute vos programmes Python). Bien choisir celui dont le nom commence par `steami-micropython-firmware-`.
 

--- a/site/docs/inovmicro-exao/i10-texte-oled.md
+++ b/site/docs/inovmicro-exao/i10-texte-oled.md
@@ -195,13 +195,15 @@ Deux raccourcis pratiques structurent l'affichage : `screen.title()` place un te
 
 Couleurs disponibles dans `steami_screen` : `BLACK`, `DARK`, `GRAY`, `LIGHT`, `WHITE` (5 niveaux de gris du SSD1327), plus `RED`, `GREEN`, `BLUE`, `YELLOW` (qui dégradent automatiquement en niveaux de gris sur l'écran monochrome).
 
-:::warning Étape importante : `screen.show()`
+:::warning[Étape importante : `screen.show()`]
+
 On peut imaginer l'écran de la STeaMi comme un tableau noir caché derrière un voile. Les fonctions `text()`, `clear()`, `pixel()`, etc. dessinent sur le tableau, mais le voile reste en place tant qu'on n'a pas appelé `screen.show()`. À ce moment-là, le voile tombe et tout ce qu'on a dessiné apparaît d'un coup.
 
 Techniquement, ce « tableau caché » s'appelle un **framebuffer** : une zone de mémoire dans laquelle on prépare l'image, avant de la transférer vers l'écran.
 :::
 
-:::tip API bas niveau
+:::tip[API bas niveau]
+
 Si vous avez besoin de coordonnées exactes (par exemple pour une animation pixel par pixel), `steami_screen` expose aussi `screen.pixel()`, `screen.line()`, `screen.rect()` et `screen.circle()`.
 :::
 

--- a/site/docs/inovmicro-exao/i10-texte-oled.md
+++ b/site/docs/inovmicro-exao/i10-texte-oled.md
@@ -202,7 +202,7 @@ On peut imaginer l'écran de la STeaMi comme un tableau noir caché derrière un
 Techniquement, ce « tableau caché » s'appelle un **framebuffer** : une zone de mémoire dans laquelle on prépare l'image, avant de la transférer vers l'écran.
 :::
 
-:::tip[API bas niveau]
+:::info[API bas niveau]
 
 Si vous avez besoin de coordonnées exactes (par exemple pour une animation pixel par pixel), `steami_screen` expose aussi `screen.pixel()`, `screen.line()`, `screen.rect()` et `screen.circle()`.
 :::

--- a/site/docs/inovmicro-exao/t03-decouverte-thonny.md
+++ b/site/docs/inovmicro-exao/t03-decouverte-thonny.md
@@ -85,7 +85,7 @@ pipx install thonny
 
 ### Installer MicroPython sur la STeaMi
 
-:::info Étape éventuellement déjà faite
+:::info[Étape éventuellement déjà faite]
 
 Une STeaMi sortie d'usine est en général livrée avec MicroPython déjà installé. Si après l'étape suivante (*Configurer Thonny pour la STeaMi*) l'invite `>>>` apparaît dans le Shell de Thonny (le signe en début de ligne qui indique que MicroPython attend une commande, équivalent du mot anglais « prompt »), cette étape d'installation est déjà faite : passez directement à la section suivante.
 
@@ -95,9 +95,16 @@ Grâce à un mode "clé USB" préinstallé en usine, la STeaMi se présente comm
 
 1. **Brancher** la STeaMi en USB (câble de données, pas un câble de charge seul).
 2. La carte apparaît comme un disque amovible nommé `STEAMI`.
-3. **Télécharger** le fichier `steami-micropython-firmware-vX.Y.Z.hex` depuis les [releases](https://github.com/steamicc/micropython-steami-lib/releases). Attention : ne pas confondre avec `steami-daplink-firmware-...hex`, qui est un autre fichier sans rapport avec MicroPython.
+3. **Télécharger** le fichier `steami-micropython-firmware-vX.Y.Z.hex` depuis les [releases](https://github.com/steamicc/micropython-steami-lib/releases).
 4. **Glisser-déposer** le `.hex` sur le disque `STEAMI`.
 5. La LED de statut clignote pendant l'écriture (~5 à 15 s), puis la carte **redémarre** avec MicroPython. **Ne pas débrancher la carte pendant le clignotement** : attendre la fin du redémarrage.
+
+:::warning[Attention au bon fichier]
+
+Ne pas confondre `steami-micropython-firmware-...hex` avec `steami-daplink-firmware-...hex`, qui est un autre fichier sans rapport avec MicroPython (c'est le logiciel de l'interface de programmation, pas celui qui exécute vos programmes Python). Bien choisir celui dont le nom commence par `steami-micropython-firmware-`.
+
+:::
+
 :::warning[Câble incompatible]
 
 Si le disque `STEAMI` n'apparaît pas, le premier réflexe est de changer de câble : un câble qui ne transporte que l'alimentation ne suffit pas, il faut un câble de données.
@@ -241,7 +248,7 @@ while True:
 - **Test rapide** : bouton **Run** (▶) ou `F5`. Le code s'exécute sur la carte sans être sauvegardé.
 - **Programme persistant** : **Fichier > Enregistrer sous... > MicroPython device**, et nommer le fichier **`main.py`**. Il sera relancé à chaque démarrage de la carte.
 
-:::info Un programme est déjà en cours d'exécution
+:::info[Un programme est déjà en cours d'exécution]
 
 Quand un programme est déjà en cours d'exécution sur la carte (par exemple un `main.py` précédemment enregistré), Thonny refuse de lancer le suivant : il faut d'abord l'interrompre avec **`Ctrl+C`** dans le panneau Shell, ou cliquer sur le bouton **Stop** (■).
 


### PR DESCRIPTION
## Summary

Corrige 5 callouts cassés dans les fiches I-Novmicro #2 + 2 problèmes de formatage (ligne vide manquante, warning à extraire d'un step de liste).

Cause racine : ancienne syntaxe Docusaurus `:::type Titre` (sans crochets) qui ne fonctionne plus en v3 — il faut `:::type[Titre]`.

## Fichiers modifiés

- `depannage.md` : 1 callout
- `t03-decouverte-thonny.md` : 2 callouts + ligne vide manquante + extraction "Attention au bon fichier" en callout dédié
- `i10-texte-oled.md` : 2 callouts + lignes vides

Closes #184

## Test plan

- [ ] `/ressources/inovmicro-exao/depannage` : section "MicroPython pas installé" → callout warning "Attention au bon fichier" bien rendu
- [ ] `/ressources/inovmicro-exao/t03-decouverte-thonny` : 3 callouts visibles (info × 2, warning × 1 ou 2)
- [ ] `/ressources/inovmicro-exao/i10-texte-oled` : warning et tip bien rendus avec leur titre

🤖 Generated with [Claude Code](https://claude.com/claude-code)