### PR TITLE
chore(catalogue): renommer 'Catégorie d'activité' en 'Thématique abordée'

### DIFF
--- a/site/src/pages/catalogue.tsx
+++ b/site/src/pages/catalogue.tsx
@@ -388,9 +388,9 @@ export default function Catalogue(): React.ReactElement {
       <main className="container margin-vert--lg">
         <h1>Catalogue des ressources</h1>
         <p>
-          Parcourez les fiches d'activité par approche pédagogique. Utilisez les filtres pour
-          affiner par projet, discipline, outil, âge, durée ou mot-clé. Chaque fiche apparaît dans
-          toutes les catégories qui la concernent.
+          Parcourez les fiches d'activité par thématique abordée. Utilisez les filtres pour affiner
+          par projet, discipline, outil, âge, durée ou mot-clé. Chaque fiche apparaît sous toutes
+          les thématiques qui la concernent.
         </p>
 
         <div
@@ -416,7 +416,7 @@ export default function Catalogue(): React.ReactElement {
               />
 
               <FilterGroup
-                legend="Catégorie d'activité"
+                legend="Thématique abordée"
                 labels={categoryFilterLabels}
                 order={CATEGORY_ORDER}
                 selected={filters.categories}


### PR DESCRIPTION
## Summary

Simple renommage du libellé du filtre (et 2 ajustements de l'intro) pour mieux refléter sa nature : c'est une **thématique transversale** abordée par la fiche, pas une catégorie d'activité (terme qui prêtait à confusion avec "Format" ou "Projet").

Les 11 valeurs et leur sémantique ne changent pas.

## Changements

- Filtre `Catégorie d'activité` → `Thématique abordée`
- Intro : "par approche pédagogique" → "par thématique abordée"
- Intro : "dans toutes les catégories" → "sous toutes les thématiques"

## Test plan

- [ ] `/catalogue` : libellé du filtre = "Thématique abordée"
- [ ] Filtrer par 1 ou 2 thématiques fonctionne comme avant
- [ ] Comportement URL inchangé (`?cat=programmation,...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)