### PR TITLE
feat(sidebar): grouper les fiches par projet avec sous-titre explicite

### DIFF
--- a/site/sidebars.ts
+++ b/site/sidebars.ts
@@ -1,44 +1,53 @@
 import type { SidebarsConfig } from '@docusaurus/plugin-content-docs';
-import { resources, categoryLabels, type Category } from './src/data/resources';
+import { resources, type Project } from './src/data/resources';
+import { projectsInfo } from './src/data/projects';
 
-// Ordre d'affichage des approches pédagogiques dans la sidebar
-const CATEGORY_ORDER: Category[] = [
-  'animation-jeunesse',
-  'programmation',
-  'robotique-ludique',
-  'exploration-scientifique',
-  'ia-esprit-critique',
-  'citoyennete-territoire',
-  'environnement-nature',
-  'sequences-debranchees',
-  'theatre-sciences',
-  'arts-creativite',
-  'makers-fabrication',
+// Ordre d'affichage des projets dans la sidebar — même ordre que la
+// page /projets : projets-du-lab d'abord, puis chronologique selon
+// l'ancienneté / la maturité des contenus dans le wiki.
+const PROJECT_ORDER: Project[] = [
+  'projets-du-lab',
+  'lets-steam',
+  'magnetics',
+  'unplugged',
+  'thedexterlab',
+  'mimesis',
+  'steamcity',
+  'robots-meet-arts',
+  'jeditrack',
+  'inovmicro-exao',
+  'youth-ai-lab',
 ];
 
-// Construit les catégories sidebar à partir des données resources.ts.
-// Chaque fiche apparaît dans chaque catégorie dont elle fait partie.
-// Tri : (sidebarOrder ?? 0, slug). Une fiche avec sidebarOrder élevé
-// (ex. dépannage transverse) reste en bas malgré son slug.
-const categorySections = CATEGORY_ORDER.map((cat) => {
+// Construit les sections de la sidebar à partir des fiches groupées
+// par projet. Le label de chaque section est de la forme :
+//   "Nom du projet — Sous-titre verbe-début"
+// (cf. champ `subtitle` dans projects.ts). Cela donne du contexte
+// d'entrée au lecteur quand il navigue d'un projet à l'autre.
+//
+// Tri intra-projet : (sidebarOrder ?? 0, slug). Une fiche avec
+// sidebarOrder élevé (ex. dépannage transverse) reste en bas
+// malgré son slug.
+const projectSections = PROJECT_ORDER.map((proj) => {
   const items = resources
-    .filter((r) => r.categories.includes(cat))
+    .filter((r) => r.project === proj)
     .map((r) => ({
       id: r.slug.replace(/^\/ressources\//, ''),
       order: r.sidebarOrder ?? 0,
     }))
     .sort((a, b) => a.order - b.order || a.id.localeCompare(b.id))
     .map((x) => x.id);
+  const info = projectsInfo[proj];
   return {
     type: 'category' as const,
-    label: categoryLabels[cat],
+    label: `${info.name} — ${info.subtitle}`,
     collapsed: true,
     items,
   };
 }).filter((section) => section.items.length > 0);
 
 const sidebars: SidebarsConfig = {
-  ressourcesSidebar: ['intro', ...categorySections],
+  ressourcesSidebar: ['intro', ...projectSections],
 };
 
 export default sidebars;

--- a/site/src/data/projects.ts
+++ b/site/src/data/projects.ts
@@ -10,6 +10,11 @@ export interface Partner {
 export interface ProjectInfo {
   id: Project;
   name: string;
+  /** Sous-titre court (verbe en début, ~30 caractères max) affiché dans
+   * la sidebar des docs à côté du nom court : "Let's STEAM — Programmer
+   * la carte STM32 sur MakeCode". Sert à donner le contexte du projet
+   * sans avoir à lire la description longue. */
+  subtitle: string;
   logo: string;
   color: string;
   colorSecondary: string;
@@ -36,6 +41,7 @@ export const projectsInfo: Record<Project, ProjectInfo> = {
   'lets-steam': {
     id: 'lets-steam',
     name: "Let's STEAM",
+    subtitle: 'Programmer la carte STM32 sur MakeCode',
     logo: '/img/logos/lets-steam.svg',
     color: '#140e4e',
     colorSecondary: '#62549F',
@@ -87,6 +93,7 @@ export const projectsInfo: Record<Project, ProjectInfo> = {
   mimesis: {
     id: 'mimesis',
     name: 'Mimesis',
+    subtitle: 'Faire des sciences grâce au théâtre',
     logo: '/img/logos/mimesis.svg',
     color: '#09246C',
     colorSecondary: '#FFB1C5',
@@ -135,6 +142,7 @@ export const projectsInfo: Record<Project, ProjectInfo> = {
   'robots-meet-arts': {
     id: 'robots-meet-arts',
     name: 'Robots Meet Arts',
+    subtitle: 'Utiliser la robotique au service des humanités',
     logo: '/img/logos/robots-meet-arts.svg',
     color: '#169da7',
     colorSecondary: '#eb407e',
@@ -186,6 +194,7 @@ export const projectsInfo: Record<Project, ProjectInfo> = {
   steamcity: {
     id: 'steamcity',
     name: 'SteamCity',
+    subtitle: 'Mener une investigation scientifique et citoyenne',
     logo: '/img/logos/steamcity.svg',
     color: '#DD5350',
     colorSecondary: '#99D69F',
@@ -237,6 +246,7 @@ export const projectsInfo: Record<Project, ProjectInfo> = {
   unplugged: {
     id: 'unplugged',
     name: 'Unplugged',
+    subtitle: "Jouer pour développer sa citoyenneté à l'école",
     logo: '/img/logos/unplugged.png',
     color: '#0081A7',
     colorSecondary: '#A06A83',
@@ -280,6 +290,7 @@ export const projectsInfo: Record<Project, ProjectInfo> = {
   jeditrack: {
     id: 'jeditrack',
     name: 'JediTrack',
+    subtitle: 'Découvrir son environnement par les sciences citoyennes',
     logo: '/img/logos/jeditrack.png',
     color: '#1198f0',
     colorSecondary: '#ef476c',
@@ -321,6 +332,7 @@ export const projectsInfo: Record<Project, ProjectInfo> = {
   thedexterlab: {
     id: 'thedexterlab',
     name: 'The Dexter Lab',
+    subtitle: 'Expérimenter les sciences en DIY',
     logo: '/img/logos/the-dexter-lab.png',
     color: '#1a4a48',
     colorSecondary: '#1a4a48',
@@ -362,6 +374,7 @@ export const projectsInfo: Record<Project, ProjectInfo> = {
   'youth-ai-lab': {
     id: 'youth-ai-lab',
     name: 'Youth AI Lab',
+    subtitle: "Explorer l'IA générative par la démarche scientifique",
     logo: '/img/logos/youth-ai-lab.png',
     color: '#b34520',
     colorSecondary: '#b34520',
@@ -410,6 +423,7 @@ export const projectsInfo: Record<Project, ProjectInfo> = {
   magnetics: {
     id: 'magnetics',
     name: 'Magnetics',
+    subtitle: 'Connecter des cartes en BLE Mesh',
     logo: '/img/logos/magnetics.png',
     color: '#094869',
     colorSecondary: '#dd5350',
@@ -448,6 +462,7 @@ export const projectsInfo: Record<Project, ProjectInfo> = {
   'inovmicro-exao': {
     id: 'inovmicro-exao',
     name: 'I-Novmicro #2 : Action EXAO',
+    subtitle: 'Découvrir et programmer la carte STeaMi',
     logo: '/img/logos/exao.png',
     color: '#8a6e18',
     colorSecondary: '#8a6e18',
@@ -490,6 +505,7 @@ export const projectsInfo: Record<Project, ProjectInfo> = {
   'projets-du-lab': {
     id: 'projets-du-lab',
     name: 'Projets du LAB',
+    subtitle: 'Découvrir nos projets makers',
     logo: '/img/logos/wikilab.svg',
     color: '#356bac',
     colorSecondary: '#e83e8c',


### PR DESCRIPTION
## Summary

Refonte de la sidebar des fiches : groupage par **projet** au lieu de catégorie pédagogique, avec un **sous-titre explicite** par projet (verbe au début).

Une fiche n'apparaît plus qu'**une seule fois**, sous son projet d'origine — fini les doublons des fiches multi-catégories.

La catégorie pédagogique reste un filtre dans le catalogue (cf. PR #186 qui la renomme en "Thématique abordée").

## Changements

- `ProjectInfo` : ajout du champ `subtitle: string`
- `projects.ts` : 11 sous-titres ajoutés (verbe-début, ~30 caractères)
- `sidebars.ts` : refonte du groupage par projet, label = `name — subtitle`
- Ordre projets : même que `/projets` (projets-du-lab d'abord, puis chronologique)

## Sous-titres validés

```
Let's STEAM        — Programmer la carte STM32 sur MakeCode
Mimesis            — Faire des sciences grâce au théâtre
Robots Meet Arts   — Utiliser la robotique au service des humanités
SteamCity          — Mener une investigation scientifique et citoyenne
Unplugged          — Jouer pour développer sa citoyenneté à l'école
JediTrack          — Découvrir son environnement par les sciences citoyennes
The Dexter Lab     — Expérimenter les sciences en DIY
Youth AI Lab       — Explorer l'IA générative par la démarche scientifique
Magnetics          — Connecter des cartes en BLE Mesh
I-Novmicro #2      — Découvrir et programmer la carte STeaMi
Projets du LAB     — Découvrir nos projets makers
```

Closes #187

## Test plan

- [ ] N'importe quelle fiche : la sidebar montre 11 sections projet, dans l'ordre attendu
- [ ] Chaque section affiche `Nom — Sous-titre`
- [ ] Une fiche multi-catégories n'apparaît plus qu'une fois
- [ ] L'ordre intra-projet (tri sidebarOrder puis slug) reste correct (dépannage en bas pour inovmicro)

🤖 Generated with [Claude Code](https://claude.com/claude-code)