### PR TITLE
fix(catalogue): thématique 'Actions d'animation jeunesse' → 'Animation jeunesse'

### DIFF
--- a/site/src/data/categories.ts
+++ b/site/src/data/categories.ts
@@ -30,5 +30,5 @@ export const categoryLabels: Record<Category, string> = {
   'makers-fabrication': '🛠️ Makers et fabrication',
   'arts-creativite': '🎨 Arts et créativité',
   'environnement-nature': '🌱 Environnement et nature',
-  'animation-jeunesse': "🎯 Actions d'animation jeunesse",
+  'animation-jeunesse': '🎯 Animation jeunesse',
 };


### PR DESCRIPTION
## Summary

Renomme le libellé de la thématique `animation-jeunesse` : "Actions d'animation jeunesse" → "Animation jeunesse".

"Actions d'…" décrivait un type d'action plutôt qu'une thématique abordée — le nouveau libellé est cohérent avec les autres (noms de thématiques, pas de phrases).

La clé technique (`animation-jeunesse`) et l'emoji ne changent pas.

## Test plan

- [ ] `/catalogue` : filtre "Thématique abordée" → l'entrée affiche "Animation jeunesse"
- [ ] Le filtrage par cette thématique fonctionne toujours

🤖 Generated with [Claude Code](https://claude.com/claude-code)