### PR TITLE
fix: corrige les images cassées de la page /about (régression #204)

### DIFF
--- a/site/src/pages/about.md
+++ b/site/src/pages/about.md
@@ -21,11 +21,11 @@ Les ressources présentes dans le wiki sont produites selon plusieurs approches 
 
 <div class="wikilab-gallery">
   <img src="/img/photos/ressources/Image collée.png" alt="Ressource pédagogique" />
-  <img src="/img/photos/ressources/Image collée (2).png" alt="Ressource pédagogique" />
-  <img src="/img/photos/ressources/Image collée (3).png" alt="Ressource pédagogique" />
-  <img src="/img/photos/ressources/Image collée (4).png" alt="Ressource pédagogique" />
-  <img src="/img/photos/ressources/Image collée (5).png" alt="Ressource pédagogique" />
-  <img src="/img/photos/ressources/Image collée (6).png" alt="Ressource pédagogique" />
+  <img src="/img/photos/ressources/image-collee-2.png" alt="Ressource pédagogique" />
+  <img src="/img/photos/ressources/image-collee-3.png" alt="Ressource pédagogique" />
+  <img src="/img/photos/ressources/image-collee-4.png" alt="Ressource pédagogique" />
+  <img src="/img/photos/ressources/image-collee-5.png" alt="Ressource pédagogique" />
+  <img src="/img/photos/ressources/image-collee-6.png" alt="Ressource pédagogique" />
 </div>
 
 ## Qui sommes-nous ?
@@ -46,11 +46,11 @@ C'est cet ancrage dans la fabrication et la médiation scientifique qui nous a a
 
 <div class="wikilab-gallery">
   <img src="/img/photos/ateliers/Image collée.png" alt="Atelier" />
-  <img src="/img/photos/ateliers/Image collée (2).png" alt="Atelier" />
-  <img src="/img/photos/ateliers/Image collée (3).png" alt="Atelier" />
-  <img src="/img/photos/ateliers/Image collée (4).png" alt="Atelier" />
-  <img src="/img/photos/ateliers/Image collée (5).png" alt="Atelier" />
-  <img src="/img/photos/ateliers/Image collée (6).png" alt="Atelier" />
+  <img src="/img/photos/ateliers/image-collee-2.png" alt="Atelier" />
+  <img src="/img/photos/ateliers/image-collee-3.png" alt="Atelier" />
+  <img src="/img/photos/ateliers/image-collee-4.png" alt="Atelier" />
+  <img src="/img/photos/ateliers/image-collee-5.png" alt="Atelier" />
+  <img src="/img/photos/ateliers/image-collee-6.png" alt="Atelier" />
 </div>
 
 **Nos valeurs : Bidouiller. Collaborer. Partager.**


### PR DESCRIPTION
## Problème

La page <https://wiki.labaixbidouille.com/about> affichait des images cassées (404 sur `Image collée (2..6).png`).

## Cause

La PR #204 a renommé `photos/{ressources,ateliers}/Image collée (2..6).png` → `image-collee-N.png`, mais son script de mise à jour des références ne scannait que `site/docs/**`. `about.md` vit dans `site/src/pages/` → ses 10 `<img src>` pointaient encore vers les anciens noms. Le build ne le détecte pas (`<img src>` statiques non validés), d'où le 404 en prod.

## Correctif

- 10 références d'`about.md` mises à jour vers les noms slugifiés.
- `Image collée.png` (sans numéro, fichier existant) inchangé.

## Vérifications

- [x] Scan `src=/img` sur tout `site/src` : **0 cassée** (avec capture parenthèses-safe).
- [x] `npm run site:build` : SUCCESS ; HTML rendu pointe vers `image-collee-N.png`.
- [x] `prettier --check` : OK.

Closes #216

## Test plan

- [ ] Après déploiement, vérifier que /about n'a plus de 404 en console.