### PR TITLE
ci: valide les références d'images locales (<img src> non couvert par le build)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   lint:
-    name: Lint (Prettier, Markdown, cspell, crosslinks)
+    name: Lint (Prettier, Markdown, cspell, crosslinks, assets)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -46,6 +46,9 @@ jobs:
 
       - name: Lint crosslinks Let's STEAM <-> I-NOVMICRO
         run: npm run lint:crosslinks
+
+      - name: Check local image assets (<img src> non couvert par le build)
+        run: npm run lint:assets
 
   build:
     name: Build Docusaurus + typecheck

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint:spell": "cspell --no-must-find-files",
     "lint:links": "docker run --rm -v $PWD:/input lycheeverse/lychee --config /input/.lychee.toml '/input/site/docs/**/*.md' '/input/README.md'",
     "lint:crosslinks": "node site/scripts/lint-crosslinks.mjs",
+    "lint:assets": "node site/scripts/check-local-assets.mjs",
     "verify-broken-links": "node site/scripts/verify-broken-links.mjs",
     "site:start": "npm --prefix site start",
     "site:build": "npm --prefix site run build",

--- a/site/scripts/check-local-assets.mjs
+++ b/site/scripts/check-local-assets.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+// Valide les références d'images locales vers site/static.
+//
+// Le build Docusaurus ne vérifie QUE les images markdown `![](...)` (via
+// onBrokenMarkdownImages) et les liens de routes internes (onBrokenLinks).
+// Les `<img src="/img/...">` (JSX/HTML) vers des fichiers statiques ne sont
+// PAS validés → une image renommée/supprimée donne un 404 silencieux en prod
+// (cf. #205, #216). Ce script comble ce trou : il scanne site/src ET site/docs
+// (le script de #204 ne couvrait que site/docs, d'où la régression #216).
+//
+// Usage : node site/scripts/check-local-assets.mjs  (ou `npm run lint:assets`)
+// Exit 1 si au moins une référence non-exceptée pointe vers un fichier absent.
+
+import { readFileSync, existsSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const STATIC_ROOT = join(REPO_ROOT, 'site', 'static');
+const SCAN_DIRS = [join(REPO_ROOT, 'site', 'src'), join(REPO_ROOT, 'site', 'docs')];
+
+// Références cassées connues et tracées ailleurs, tolérées pour ne pas
+// bloquer la CI. Retirer une entrée dès que l'issue liée est résolue.
+const KNOWN_MISSING = new Set([
+  // cf. #205 — galerie « Exemple de Skill Tree » : images jamais fournies.
+  '/img/ressources/jeditrack/skill-trees/image.png',
+  '/img/ressources/jeditrack/skill-trees/image_1.png',
+  '/img/ressources/jeditrack/skill-trees/image_2.png',
+]);
+
+const IMG_EXT = String.raw`\.(?:png|jpe?g|svg|webp|gif|avif)`;
+// Capture le contenu COMPLET entre délimiteurs (tolère parenthèses, espaces,
+// accents — le piège récurrent est un regex `[^)]` qui rate `… (2).png`).
+const PATTERNS = [
+  new RegExp(`src="(/img/[^"]+?${IMG_EXT})"`, 'gi'), // <img src="…"> JSX/HTML
+  new RegExp(`!\\[[^\\]]*\\]\\((/img/[^)\\s]+?${IMG_EXT})\\)`, 'gi'), // markdown ![](…)
+  new RegExp(`(?:image|thumbnail|icon):\\s*'(/img/[^']+?${IMG_EXT})'`, 'gi'), // data files
+];
+
+function walk(dir, acc = []) {
+  if (!existsSync(dir)) return acc;
+  for (const e of readdirSync(dir, { withFileTypes: true })) {
+    const f = join(dir, e.name);
+    if (e.isDirectory()) walk(f, acc);
+    else if (/\.(mdx?|tsx?|jsx?)$/.test(e.name)) acc.push(f);
+  }
+  return acc;
+}
+
+let checked = 0;
+const broken = [];
+const knownHit = new Set();
+
+for (const root of SCAN_DIRS) {
+  for (const file of walk(root)) {
+    const txt = readFileSync(file, 'utf8');
+    for (const re of PATTERNS) {
+      for (const m of txt.matchAll(re)) {
+        const ref = m[1];
+        checked++;
+        let decoded;
+        try {
+          decoded = decodeURIComponent(ref);
+        } catch {
+          decoded = ref;
+        }
+        // Placeholders du template (<id-fiche>, <svg>…) : on ignore.
+        if (decoded.includes('<')) continue;
+        const fsPath = join(STATIC_ROOT, decoded);
+        if (existsSync(fsPath) && statSync(fsPath).isFile()) continue;
+        if (KNOWN_MISSING.has(decoded)) {
+          knownHit.add(decoded);
+          continue;
+        }
+        broken.push({ file: file.replace(REPO_ROOT + '/', ''), ref });
+      }
+    }
+  }
+}
+
+console.log(`Références d'images vérifiées : ${checked}`);
+if (knownHit.size) {
+  console.log(`Exceptions connues tolérées : ${knownHit.size} (cf. KNOWN_MISSING)`);
+}
+
+if (broken.length === 0) {
+  console.log("✓ Aucune référence d'image cassée.");
+  process.exit(0);
+}
+
+console.error(`\n✖ ${broken.length} référence(s) d'image cassée(s) :`);
+for (const b of broken) console.error(`  ${b.file}  →  ${b.ref}`);
+console.error(
+  '\nVérifiez le nom/chemin du fichier sous site/static, ou ajoutez une ' +
+    'exception tracée dans KNOWN_MISSING si une issue couvre déjà le cas.',
+);
+process.exit(1);

--- a/site/scripts/check-local-assets.mjs
+++ b/site/scripts/check-local-assets.mjs
@@ -34,7 +34,9 @@ const IMG_EXT = String.raw`\.(?:png|jpe?g|svg|webp|gif|avif)`;
 // accents — le piège récurrent est un regex `[^)]` qui rate `… (2).png`).
 const PATTERNS = [
   new RegExp(`src="(/img/[^"]+?${IMG_EXT})"`, 'gi'), // <img src="…"> JSX/HTML
-  new RegExp(`!\\[[^\\]]*\\]\\((/img/[^)\\s]+?${IMG_EXT})\\)`, 'gi'), // markdown ![](…)
+  // markdown ![](…) : l'URL peut contenir des parenthèses équilibrées
+  // (ex. `…image_(2).png`) — un simple `[^)]` les raterait (cf. #216).
+  new RegExp(`!\\[[^\\]]*\\]\\((/img/(?:[^()\\s]|\\([^()]*\\))*?${IMG_EXT})\\)`, 'gi'),
   new RegExp(`(?:image|thumbnail|icon):\\s*'(/img/[^']+?${IMG_EXT})'`, 'gi'), // data files
 ];
 
@@ -67,7 +69,10 @@ for (const root of SCAN_DIRS) {
         }
         // Placeholders du template (<id-fiche>, <svg>…) : on ignore.
         if (decoded.includes('<')) continue;
-        const fsPath = join(STATIC_ROOT, decoded);
+        // `decoded` commence par "/img/…" ; on retire le slash de tête pour
+        // joindre sous STATIC_ROOT sans ambiguïté (path.join le gère déjà,
+        // mais on est explicite).
+        const fsPath = join(STATIC_ROOT, decoded.replace(/^\//, ''));
         if (existsSync(fsPath) && statSync(fsPath).isFile()) continue;
         if (KNOWN_MISSING.has(decoded)) {
           knownHit.add(decoded);


### PR DESCRIPTION
## Résumé

Ajoute un validateur d'assets locaux en CI pour attraper les `<img src="/img/...">` cassés — que le build Docusaurus **ne détecte pas** (il ne valide que les images markdown `![](...)` et les routes internes). Ce trou a causé deux 404 silencieux en prod : #205 (skill-trees) et #216 (page /about).

Closes #219.

## Changements

- **`site/scripts/check-local-assets.mjs`** (`npm run lint:assets`) :
  - scanne **`site/src` ET `site/docs`** (`.md/.mdx/.tsx/.ts`) — le renommage #204 ne couvrait que `site/docs/`, d'où la régression #216 ;
  - extrait `src="..."`, markdown `![](...)`, et champs data `image/thumbnail/icon` ;
  - **extraction tolérante aux parenthèses/espaces/accents** (le piège récurrent : un regex `[^)]` rate `Image collée (2).png`) ;
  - décode l'URL et vérifie l'existence sous `site/static` ; `exit 1` sinon ;
  - ignore les placeholders du `_template` ; tolère une liste `KNOWN_MISSING` d'exceptions tracées.
- **`build.yml`** : nouvelle étape `npm run lint:assets` dans le job lint.

## Note sur #205

Les 3 images manquantes de `skill-trees.md` (#205, décision de contenu revenant à Man-BAL) sont listées dans `KNOWN_MISSING` avec renvoi à l'issue, pour ne pas bloquer la CI. À retirer dès que #205 est résolue.

## Vérifications

- [x] `npm run lint:assets` : **1187 références vérifiées, 0 cassée** (3 exceptions tolérées).
- [x] `prettier --check` : OK.

## Test plan

- [ ] CI verte (le job lint inclut désormais l'étape assets).
- [ ] (optionnel) Casser volontairement un `<img src>` en local et vérifier que `npm run lint:assets` sort en erreur.