### PR TITLE
fix(css): centrer les légendes d'images alignées à gauche

### DIFF
--- a/site/src/css/custom.css
+++ b/site/src/css/custom.css
@@ -190,6 +190,15 @@
   padding-top: 0.5rem;
 }
 
+/* MDX enveloppe le texte d'une figcaption multi-lignes dans un <p>. Sans
+ * cette règle, ce <p> hérite de `.markdown p { text-align: justify }` et
+ * la légende apparaît alignée à gauche sous une image centrée. On force
+ * le centrage (et on annule la marge du <p>). */
+.markdown figcaption p {
+  text-align: center;
+  margin: 0;
+}
+
 /* Toute figure avec figcaption est automatiquement centrée + image centrée */
 .markdown figure:has(figcaption) {
   text-align: center;


### PR DESCRIPTION
## Summary

Corrige les **légendes alignées à gauche sous des images centrées** (ex. « La LED RGB intégrée à la face avant de la STeaMi »).

**Cause** : MDX enveloppe le texte d'une figcaption dans un `<p>`, qui hérite de `.markdown p { text-align: justify }` (spécificité supérieure au centrage de la figcaption).

**Fix** : une règle CSS `.markdown figcaption p { text-align: center; margin: 0 }` qui corrige toutes les figcaptions du site d'un coup.

Closes #226

## Test plan

- [ ] `/ressources/inovmicro-exao/i01-led` : la légende sous l'image LED est centrée
- [ ] Vérifier quelques autres fiches à figures (steamcity, thedexterlab, robots-meet-arts) : légendes centrées
- [ ] Les légendes volontairement alignées à gauche (si tu en veux) ne sont pas concernées par cette PR

> ⚠️ Draft — en attente de validation visuelle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)