### PR TITLE
feat(inovmicro-exao): bouton de téléchargement PDF sur 6 fiches

### DIFF
--- a/site/docs/inovmicro-exao/i01-led.md
+++ b/site/docs/inovmicro-exao/i01-led.md
@@ -27,6 +27,8 @@ sidebar_position: 8
 - 1 ordinateur sous Windows, macOS ou Linux
 - Un IDE compatible MicroPython : Thonny (voir la fiche [Thonny : Prise en main de MicroPython](/ressources/inovmicro-exao/t03-decouverte-thonny)) ou tout autre éditeur compatible (Mu, VS Code, Vittascience, `mpremote`...).
 
+<PdfLink href="/pdf/inovmicro-exao/STeaMi_LED.pdf">Télécharger en PDF</PdfLink>
+
 </div>
 <img src="/img/ressources/inovmicro-exao/i01-led/icone.png" alt="Faire clignoter une LED" style={{width: '225px', height: '225px', objectFit: 'contain', flexShrink: 0}} />
 </div>

--- a/site/docs/inovmicro-exao/i03-boutons.md
+++ b/site/docs/inovmicro-exao/i03-boutons.md
@@ -27,6 +27,8 @@ sidebar_position: 10
 - 1 ordinateur sous Windows, macOS ou Linux
 - Un IDE compatible MicroPython : Thonny (voir la fiche [Thonny : Prise en main de MicroPython](/ressources/inovmicro-exao/t03-decouverte-thonny)) ou tout autre éditeur compatible (Mu, VS Code, Vittascience, `mpremote`...).
 
+<PdfLink href="/pdf/inovmicro-exao/STeaMi_Boutons.pdf">Télécharger en PDF</PdfLink>
+
 </div>
 <img src="/img/ressources/inovmicro-exao/i03-boutons/icone.png" alt="Boutons-poussoirs de la STeaMi" style={{width: '225px', height: '225px', objectFit: 'contain', flexShrink: 0}} />
 </div>

--- a/site/docs/inovmicro-exao/i04-capteur-lumiere.md
+++ b/site/docs/inovmicro-exao/i04-capteur-lumiere.md
@@ -27,6 +27,8 @@ sidebar_position: 11
 - 1 câble USB de données (micro-USB pour la STeaMi V1, USB-C pour la STeaMi V2).
 - 1 ordinateur sous Windows, macOS ou Linux
 - Un IDE MicroPython installé et configuré pour la STeaMi. Voir la fiche [Thonny : Prise en main de MicroPython](/ressources/inovmicro-exao/t03-decouverte-thonny) pour la mise en place, tout autre éditeur compatible MicroPython (Mu, VS Code, Vittascience, `mpremote`...) fonctionne aussi.
+<PdfLink href="/pdf/inovmicro-exao/STeaMi_Lumiere.pdf">Télécharger en PDF</PdfLink>
+
 </div>
 <img src="/img/ressources/inovmicro-exao/i04-capteur-lumiere/icone.png" alt="Capteur de lumière sur la STeaMi" style={{width: '225px', height: '225px', objectFit: 'contain', flexShrink: 0}} />
 </div>

--- a/site/docs/inovmicro-exao/i06-code-morse.md
+++ b/site/docs/inovmicro-exao/i06-code-morse.md
@@ -27,6 +27,8 @@ sidebar_position: 13
 - 1 ordinateur sous Windows, macOS ou Linux
 - Un IDE compatible MicroPython : Thonny (voir la fiche [Thonny : Prise en main de MicroPython](/ressources/inovmicro-exao/t03-decouverte-thonny)) ou tout autre éditeur compatible (Mu, VS Code, Vittascience, `mpremote`...).
 
+<PdfLink href="/pdf/inovmicro-exao/STeaMi_Morse.pdf">Télécharger en PDF</PdfLink>
+
 </div>
 <img src="/img/ressources/inovmicro-exao/i06-code-morse/icone.png" alt="Code Morse sur la STeaMi" style={{width: '225px', height: '225px', objectFit: 'contain', flexShrink: 0}} />
 </div>

--- a/site/docs/inovmicro-exao/i10-texte-oled.md
+++ b/site/docs/inovmicro-exao/i10-texte-oled.md
@@ -27,6 +27,8 @@ sidebar_position: 17
 - 1 ordinateur sous Windows, macOS ou Linux
 - Un IDE compatible MicroPython : Thonny (voir la fiche [Thonny : Prise en main de MicroPython](/ressources/inovmicro-exao/t03-decouverte-thonny)) ou tout autre éditeur compatible (Mu, VS Code, Vittascience, `mpremote`...).
 
+<PdfLink href="/pdf/inovmicro-exao/STeaMi_Ecran.pdf">Télécharger en PDF</PdfLink>
+
 </div>
 <img src="/img/ressources/inovmicro-exao/i10-texte-oled/icone.png" alt="Écran OLED de la STeaMi affichant du texte" style={{width: '225px', height: '225px', objectFit: 'contain', flexShrink: 0}} />
 </div>

--- a/site/docs/inovmicro-exao/t03-decouverte-thonny.md
+++ b/site/docs/inovmicro-exao/t03-decouverte-thonny.md
@@ -27,6 +27,8 @@ sidebar_position: 3
 - 1 ordinateur sous Windows, macOS ou Linux
 - [Thonny](https://thonny.org/) installé (version 4.x ou supérieure)
 - Le programme MicroPython STeaMi `.hex` ([dernière release](https://github.com/steamicc/micropython-steami-lib/releases))
+<PdfLink href="/pdf/inovmicro-exao/STeaMi_Thonny.pdf">Télécharger en PDF</PdfLink>
+
 </div>
 <img src="/img/ressources/inovmicro-exao/t03-decouverte-thonny/Thonny.png" alt="Logo Thonny" style={{width: '225px', height: '225px', objectFit: 'contain', flexShrink: 0}} />
 </div>


### PR DESCRIPTION
## Summary

Ajoute le bouton `<PdfLink>` de téléchargement sur 6 fiches I-Novmicro #2 :

| Fiche | PDF référencé |
|---|---|
| i01-led | `/pdf/inovmicro-exao/STeaMi_LED.pdf` |
| i03-boutons | `/pdf/inovmicro-exao/STeaMi_Boutons.pdf` |
| i04-capteur-lumiere | `/pdf/inovmicro-exao/STeaMi_Lumiere.pdf` |
| i06-code-morse | `/pdf/inovmicro-exao/STeaMi_Morse.pdf` |
| t03-decouverte-thonny | `/pdf/inovmicro-exao/STeaMi_Thonny.pdf` |
| i10-texte-oled | `/pdf/inovmicro-exao/STeaMi_Ecran.pdf` |

Bouton placé après la liste de matériel (convention).

## ⚠️ Action complémentaire requise

Les PDFs sont **externalisés** (cf. #203) : il faut déposer les 6 fichiers dans le repo **wikilab-assets** sous `pdf/inovmicro-exao/` avec ces noms exacts. Tant qu'ils n'y sont pas, le bouton pointe vers une 404.

Closes #228

## Test plan

- [ ] Les 6 fiches affichent le bouton rose "Télécharger en PDF" après le matériel
- [ ] Une fois les PDFs poussés sur wikilab-assets, le téléchargement fonctionne
- [ ] Build OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)