### PR TITLE
fix(inovmicro-exao): placement des boutons PDF (Thonny + Capteur de lumière)

### DIFF
--- a/site/docs/inovmicro-exao/i04-capteur-lumiere.md
+++ b/site/docs/inovmicro-exao/i04-capteur-lumiere.md
@@ -27,6 +27,7 @@ sidebar_position: 11
 - 1 câble USB de données (micro-USB pour la STeaMi V1, USB-C pour la STeaMi V2).
 - 1 ordinateur sous Windows, macOS ou Linux
 - Un IDE MicroPython installé et configuré pour la STeaMi. Voir la fiche [Thonny : Prise en main de MicroPython](/ressources/inovmicro-exao/t03-decouverte-thonny) pour la mise en place, tout autre éditeur compatible MicroPython (Mu, VS Code, Vittascience, `mpremote`...) fonctionne aussi.
+
 <PdfLink href="/pdf/inovmicro-exao/STeaMi_Lumiere.pdf">Télécharger en PDF</PdfLink>
 
 </div>

--- a/site/docs/inovmicro-exao/t03-decouverte-thonny.md
+++ b/site/docs/inovmicro-exao/t03-decouverte-thonny.md
@@ -27,6 +27,7 @@ sidebar_position: 3
 - 1 ordinateur sous Windows, macOS ou Linux
 - [Thonny](https://thonny.org/) installé (version 4.x ou supérieure)
 - Le programme MicroPython STeaMi `.hex` ([dernière release](https://github.com/steamicc/micropython-steami-lib/releases))
+
 <PdfLink href="/pdf/inovmicro-exao/STeaMi_Thonny.pdf">Télécharger en PDF</PdfLink>
 
 </div>


### PR DESCRIPTION
## Résumé

Sur 2 fiches I-Novmicro #2, le bouton `<PdfLink>` était collé au dernier élément de la liste « Matériel et Montage » (pas de ligne vide), donc MDX l'absorbait dans le dernier point de liste et l'affichait mal placé.

- `t03-decouverte-thonny.md`
- `i04-capteur-lumiere.md`

Ajout d'une ligne vide avant `<PdfLink>` pour aligner sur les 4 autres fiches (`i01-led`, `i03-boutons`, `i06-code-morse`, `i10-texte-oled`) qui s'affichent déjà correctement.

Closes #231

## Test plan

- [ ] `npm run site:build` vert (CI)
- [ ] Vérifier visuellement que le bouton est sous la liste, sur sa propre ligne, sur les 2 fiches

🤖 Generated with [Claude Code](https://claude.com/claude-code)