### PR TITLE
feat(sidebar): suivre l'ordre du catalogue au lieu de l'alphabétique

### DIFF
--- a/site/sidebars.ts
+++ b/site/sidebars.ts
@@ -25,9 +25,11 @@ const PROJECT_ORDER: Project[] = [
 // (cf. champ `subtitle` dans projects.ts). Cela donne du contexte
 // d'entrée au lecteur quand il navigue d'un projet à l'autre.
 //
-// Tri intra-projet : (sidebarOrder ?? 0, slug). Une fiche avec
-// sidebarOrder élevé (ex. dépannage transverse) reste en bas
-// malgré son slug.
+// Tri intra-projet : on suit l'ordre du tableau `resources.ts`
+// (le même que la page /catalogue). Le tri par `sidebarOrder` seul
+// est stable, donc l'ordre source est préservé ; `sidebarOrder` ne
+// sert que d'exception pour forcer une position (ex. `depannage: 99`
+// reste en bas malgré sa place dans le tableau).
 const projectSections = PROJECT_ORDER.map((proj) => {
   const items = resources
     .filter((r) => r.project === proj)
@@ -35,7 +37,7 @@ const projectSections = PROJECT_ORDER.map((proj) => {
       id: r.slug.replace(/^\/ressources\//, ''),
       order: r.sidebarOrder ?? 0,
     }))
-    .sort((a, b) => a.order - b.order || a.id.localeCompare(b.id))
+    .sort((a, b) => a.order - b.order)
     .map((x) => x.id);
   const info = projectsInfo[proj];
   return {


### PR DESCRIPTION
## Résumé

Aligne l'ordre intra-projet du sidebar sur celui de la page `/catalogue` (ordre du tableau `resources.ts`), au lieu de l'alphabétique actuel.

Modification d'une ligne dans `sidebars.ts` : tri par `sidebarOrder` seul (le tri JS est stable → l'ordre source est conservé). `sidebarOrder` reste un mécanisme d'exception (`depannage: 99` reste en bas).

## Impact

7 projets sur 11 changent d'ordre interne : inovmicro-exao, steamcity, thedexterlab, jeditrack, projets-du-lab, magnetics, youth-ai-lab. Inchangés : Let's STEAM, Unplugged, Mimesis, Robots Meet Arts.

Gains notables :
- **inovmicro** : éditeurs (Thonny, VS Code…) groupés avant les activités.
- **steamcity / thedexterlab** : fiches `programmation-*` regroupées en fin de liste au lieu d'être éparpillées.
- **jeditrack** : mini-projets 1→4 en tête.

Aucun impact sur les URLs, les liens internes ou le fil d'Ariane. Seule la pagination « Précédent/Suivant » suit le nouvel ordre.

Closes #235

## Test plan

- [ ] `npm run site:build` vert (CI)
- [ ] Vérifier l'ordre du sidebar par projet en local

🤖 Generated with [Claude Code](https://claude.com/claude-code)