### PR TITLE
feat(css): titres en Outfit + titre hero en Righteous + retrait des ombres

### DIFF
--- a/site/src/css/custom.css
+++ b/site/src/css/custom.css
@@ -317,11 +317,21 @@ article > table:first-of-type {
 
 .wikilab-hero__title {
   font-family: var(--wikilab-brand-font);
-  font-size: 3.25rem !important;
+  font-size: 4.5rem !important;
   font-weight: 400 !important;
-  letter-spacing: -0.01em;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
   color: #fff;
   text-shadow: none;
+}
+
+.wikilab-hero__title::after {
+  content: '';
+  display: block;
+  width: 140px;
+  height: 2px;
+  margin: 1rem auto 0;
+  background: rgba(255, 255, 255, 0.85);
 }
 
 .wikilab-hero__subtitle {
@@ -1049,10 +1059,15 @@ aside input[type='checkbox'] {
   height: 100%;
 }
 
+/* Espacement entre le logo et le nom du site (les liens gardent leur espacement par défaut) */
+.navbar__logo {
+  margin-right: 1.5rem;
+}
+
 .navbar__title {
-  font-family: var(--wikilab-brand-font);
-  font-weight: 400;
-  font-size: 1.6rem;
+  font-family: var(--ifm-heading-font-family);
+  font-weight: 500;
+  font-size: 1.7rem;
 }
 
 .navbar__link {

--- a/site/src/css/custom.css
+++ b/site/src/css/custom.css
@@ -328,8 +328,8 @@ article > table:first-of-type {
 .wikilab-hero__title::after {
   content: '';
   display: block;
-  width: 140px;
-  height: 2px;
+  width: 240px;
+  height: 1px;
   margin: 1rem auto 0;
   background: rgba(255, 255, 255, 0.85);
 }

--- a/site/src/css/custom.css
+++ b/site/src/css/custom.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&family=Space+Grotesk:wght@500;600;700&display=swap');
 
 :root {
   /* Primaire — Bleu */
@@ -20,9 +20,9 @@
   --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
   --ifm-font-family-base: 'Nunito', system-ui, -apple-system, sans-serif;
-  --ifm-heading-font-family: 'Nunito', system-ui, -apple-system, sans-serif;
+  --ifm-heading-font-family: 'Space Grotesk', 'Nunito', system-ui, -apple-system, sans-serif;
   --ifm-font-weight-bold: 700;
-  --ifm-heading-font-weight: 800;
+  --ifm-heading-font-weight: 700;
   --ifm-border-radius: 10px;
   --ifm-navbar-background-color: #ffffff;
   --ifm-footer-background-color: #1e2a3a;

--- a/site/src/css/custom.css
+++ b/site/src/css/custom.css
@@ -316,6 +316,7 @@ article > table:first-of-type {
 }
 
 .wikilab-hero__title {
+  display: inline-block;
   font-family: var(--wikilab-brand-font);
   font-size: 4.5rem !important;
   font-weight: 400 !important;
@@ -328,9 +329,9 @@ article > table:first-of-type {
 .wikilab-hero__title::after {
   content: '';
   display: block;
-  width: 240px;
+  width: calc(100% + 3rem);
   height: 1px;
-  margin: 1rem auto 0;
+  margin: 1rem 0 0 -1.5rem;
   background: rgba(255, 255, 255, 0.85);
 }
 

--- a/site/src/css/custom.css
+++ b/site/src/css/custom.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&family=Space+Grotesk:wght@500;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&family=Sora:wght@500;600;700&display=swap');
 
 :root {
   /* Primaire — Bleu */
@@ -20,7 +20,7 @@
   --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
   --ifm-font-family-base: 'Nunito', system-ui, -apple-system, sans-serif;
-  --ifm-heading-font-family: 'Space Grotesk', 'Nunito', system-ui, -apple-system, sans-serif;
+  --ifm-heading-font-family: 'Sora', 'Nunito', system-ui, -apple-system, sans-serif;
   --ifm-font-weight-bold: 700;
   --ifm-heading-font-weight: 700;
   --ifm-border-radius: 10px;

--- a/site/src/css/custom.css
+++ b/site/src/css/custom.css
@@ -1046,7 +1046,8 @@ aside input[type='checkbox'] {
 }
 
 .navbar__title {
-  font-weight: 800;
+  font-family: var(--ifm-heading-font-family);
+  font-weight: 700;
   font-size: 1.25rem;
 }
 

--- a/site/src/css/custom.css
+++ b/site/src/css/custom.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&family=Outfit:wght@500;600;700;800&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&family=Outfit:wght@500;600;700&family=Righteous&display=swap');
 
 :root {
   /* Primaire — Bleu */
@@ -21,8 +21,9 @@
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
   --ifm-font-family-base: 'Nunito', system-ui, -apple-system, sans-serif;
   --ifm-heading-font-family: 'Outfit', 'Nunito', system-ui, -apple-system, sans-serif;
+  --wikilab-brand-font: 'Righteous', system-ui, -apple-system, sans-serif;
   --ifm-font-weight-bold: 700;
-  --ifm-heading-font-weight: 700;
+  --ifm-heading-font-weight: 600;
   --ifm-border-radius: 10px;
   --ifm-navbar-background-color: #ffffff;
   --ifm-footer-background-color: #1e2a3a;
@@ -315,9 +316,10 @@ article > table:first-of-type {
 }
 
 .wikilab-hero__title {
-  font-size: 3rem !important;
-  font-weight: 800 !important;
-  letter-spacing: -0.02em;
+  font-family: var(--wikilab-brand-font);
+  font-size: 3.25rem !important;
+  font-weight: 400 !important;
+  letter-spacing: -0.01em;
   color: #fff;
   text-shadow: none;
 }
@@ -1048,9 +1050,9 @@ aside input[type='checkbox'] {
 }
 
 .navbar__title {
-  font-family: var(--ifm-heading-font-family);
-  font-weight: 700;
-  font-size: 1.25rem;
+  font-family: var(--wikilab-brand-font);
+  font-weight: 400;
+  font-size: 1.6rem;
 }
 
 .navbar__link {

--- a/site/src/css/custom.css
+++ b/site/src/css/custom.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&family=Sora:wght@500;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&family=Outfit:wght@500;600;700;800&display=swap');
 
 :root {
   /* Primaire — Bleu */
@@ -20,7 +20,7 @@
   --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
   --ifm-font-family-base: 'Nunito', system-ui, -apple-system, sans-serif;
-  --ifm-heading-font-family: 'Sora', 'Nunito', system-ui, -apple-system, sans-serif;
+  --ifm-heading-font-family: 'Outfit', 'Nunito', system-ui, -apple-system, sans-serif;
   --ifm-font-weight-bold: 700;
   --ifm-heading-font-weight: 700;
   --ifm-border-radius: 10px;
@@ -319,6 +319,7 @@ article > table:first-of-type {
   font-weight: 800 !important;
   letter-spacing: -0.02em;
   color: #fff;
+  text-shadow: none;
 }
 
 .wikilab-hero__subtitle {
@@ -628,6 +629,7 @@ article > table:first-of-type {
 .wikilab-project-hero__title {
   color: #fff;
   margin-bottom: 0.5rem;
+  text-shadow: none;
 }
 
 .wikilab-project-hero__summary {


### PR DESCRIPTION
## Résumé

Refonte de la typographie des titres dans `site/src/css/custom.css`.

- **Titres (`h1`–`h6`)** : `--ifm-heading-font-family: 'Outfit', 'Nunito', system-ui…`, `--ifm-heading-font-weight: 600`.
- **Titre hero / marque** : nouvelle variable `--wikilab-brand-font: 'Righteous'` (titre d'accueil, 4.5rem, weight 400).
- Import Google Fonts : Nunito + Outfit + Righteous.
- **Retrait des ombres** (`text-shadow: none`) sur les titres.

> Note : la première version de cette branche visait « Space Grotesk / 700 » (d'où le nom de branche), mais le choix final est **Outfit (600) + Righteous**. Description alignée sur le code (cf. revue Copilot).

## Vérifications

- [x] Build + lint CI : verts.
- [ ] Vérifier en preview le rendu des titres (Outfit) et du titre d'accueil (Righteous).
