### PR TITLE
docs(inovmicro-exao): titres verbe-en-tête (Lot 1)

### DIFF
--- a/site/docs/inovmicro-exao/decouverte-steami.md
+++ b/site/docs/inovmicro-exao/decouverte-steami.md
@@ -157,7 +157,7 @@ Pour les éditeurs MakeCode, l'équivalent passe par le bloc _allumer la LED_ + 
 
 :::info[Notes pour l'enseignant·e]
 
-Le glisser-déposer rend la STeaMi accessible aux débutant·es : pas besoin d'installer un IDE complexe pour le tout premier programme. Les élèves peuvent développer dans l'éditeur web puis copier le fichier en un clic. Pour aller plus loin et bénéficier d'une console interactive, voir la fiche [Thonny : prise en main de MicroPython](/ressources/inovmicro-exao/t03-decouverte-thonny).
+Le glisser-déposer rend la STeaMi accessible aux débutant·es : pas besoin d'installer un IDE complexe pour le tout premier programme. Les élèves peuvent développer dans l'éditeur web puis copier le fichier en un clic. Pour aller plus loin et bénéficier d'une console interactive, voir la fiche [Prendre en main MicroPython avec Thonny](/ressources/inovmicro-exao/t03-decouverte-thonny).
 
 :::
 
@@ -173,7 +173,7 @@ Une fois la LED qui clignote validée, plusieurs pistes permettent d'explorer le
 
 Pour les autres capteurs (température et humidité via le HTS221, accélération via l'ISM330DL, pression atmosphérique, magnétomètre), des fiches dédiées sont en préparation dans le cadre du projet I-Novmicro #2.
 
-En cas de problème (carte qui n'apparaît pas, port série introuvable, console qui reste muette), consulter la fiche [Dépannage STeaMi](/ressources/inovmicro-exao/depannage) avant de creuser plus loin.
+En cas de problème (carte qui n'apparaît pas, port série introuvable, console qui reste muette), consulter la fiche [Dépanner la STeaMi](/ressources/inovmicro-exao/depannage) avant de creuser plus loin.
 
 ---
 

--- a/site/docs/inovmicro-exao/depannage.md
+++ b/site/docs/inovmicro-exao/depannage.md
@@ -1,13 +1,13 @@
 ---
 id: depannage
-title: Dépannage STeaMi
-sidebar_label: 'Dépannage'
+title: Dépanner la STeaMi
+sidebar_label: 'Dépanner'
 ---
 
 <div style={{display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: '2rem', marginBottom: '1.5rem'}}>
 <div style={{flex: 1}}>
 
-# Dépannage STeaMi
+# Dépanner la STeaMi
 
 <div style={{display: 'flex', gap: '0.5rem', flexWrap: 'wrap', marginBottom: '1rem'}}>
   <span className="badge badge--primary">Informatique</span>
@@ -84,7 +84,7 @@ Le port apparaît sous la forme `/dev/cu.usbmodemXXXX` (le suffixe est généré
 
 **Cause** : la carte a peut-être un autre logiciel installé en interne (MakeCode, CODAL, ou rien) au lieu de MicroPython.
 
-**Solution** : (ré)installer MicroPython STeaMi en suivant la procédure de la fiche [Thonny : Prise en main de MicroPython](/ressources/inovmicro-exao/t03-decouverte-thonny), section *« Installer MicroPython sur la STeaMi »*. En résumé :
+**Solution** : (ré)installer MicroPython STeaMi en suivant la procédure de la fiche [Prendre en main MicroPython avec Thonny](/ressources/inovmicro-exao/t03-decouverte-thonny), section *« Installer MicroPython sur la STeaMi »*. En résumé :
 
 1. Télécharger le fichier `steami-micropython-firmware-vX.Y.Z.hex` (le logiciel interne MicroPython de la STeaMi) depuis les [versions publiées sur GitHub](https://github.com/steamicc/micropython-steami-lib/releases).
 2. Glisser ce fichier sur le disque `STEAMI` qui apparaît à l'ordinateur.
@@ -150,7 +150,7 @@ Le programme reste accessible et exécutable manuellement (bouton Run de l'IDE),
 
 ## Ressources
 
-- [Thonny : Prise en main de MicroPython sur la STeaMi](/ressources/inovmicro-exao/t03-decouverte-thonny) : installation et configuration de l'IDE de référence
+- [Prendre en main MicroPython avec Thonny](/ressources/inovmicro-exao/t03-decouverte-thonny) : installation et configuration de l'IDE de référence
 - [Wiki STeaMi : matériel](https://wiki.steami.cc/docs/hardware/) : pinout et caractéristiques de la carte
 - [Documentation MicroPython](https://docs.micropython.org/) : référence du langage et des modules
 

--- a/site/docs/inovmicro-exao/i01-led.md
+++ b/site/docs/inovmicro-exao/i01-led.md
@@ -25,7 +25,7 @@ sidebar_position: 8
 - 1 carte STeaMi
 - 1 câble USB de données (micro-USB pour la STeaMi V1, USB-C pour la STeaMi V2).
 - 1 ordinateur sous Windows, macOS ou Linux
-- Un IDE compatible MicroPython : Thonny (voir la fiche [Thonny : Prise en main de MicroPython](/ressources/inovmicro-exao/t03-decouverte-thonny)) ou tout autre éditeur compatible (Mu, VS Code, Vittascience, `mpremote`...).
+- Un IDE compatible MicroPython : Thonny (voir la fiche [Prendre en main MicroPython avec Thonny](/ressources/inovmicro-exao/t03-decouverte-thonny)) ou tout autre éditeur compatible (Mu, VS Code, Vittascience, `mpremote`...).
 
 <PdfLink href="/pdf/inovmicro-exao/STeaMi_LED.pdf">Télécharger en PDF</PdfLink>
 
@@ -81,7 +81,7 @@ La LED RGB de la STeaMi se trouve sur la face avant. Chaque couleur est pilotée
 
 ### Connecter la carte à l'ordinateur
 
-Brancher la STeaMi à l'ordinateur via le câble USB. Si l'IDE est déjà configuré (voir la fiche [Thonny : Prise en main de MicroPython](/ressources/inovmicro-exao/t03-decouverte-thonny) pour la mise en place initiale), la console MicroPython doit afficher `>>>`.
+Brancher la STeaMi à l'ordinateur via le câble USB. Si l'IDE est déjà configuré (voir la fiche [Prendre en main MicroPython avec Thonny](/ressources/inovmicro-exao/t03-decouverte-thonny) pour la mise en place initiale), la console MicroPython doit afficher `>>>`.
 
 ---
 

--- a/site/docs/inovmicro-exao/i02-premier-circuit-breadboard.md
+++ b/site/docs/inovmicro-exao/i02-premier-circuit-breadboard.md
@@ -1,14 +1,14 @@
 ---
 id: i02-premier-circuit-breadboard
-title: Premier circuit sur breadboard
-sidebar_label: "Premier circuit sur breadboard"
+title: Construire un premier circuit sur breadboard
+sidebar_label: "Construire un premier circuit sur breadboard"
 sidebar_position: 2
 ---
 
 <div style={{display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: '2rem', marginBottom: '1.5rem'}}>
 <div style={{flex: 1}}>
 
-# Premier circuit sur breadboard
+# Construire un premier circuit sur breadboard
 
 <div style={{display: 'flex', gap: '0.5rem', flexWrap: 'wrap', marginBottom: '1rem'}}>
   <span className="badge badge--primary">Informatique</span>

--- a/site/docs/inovmicro-exao/i03-boutons.md
+++ b/site/docs/inovmicro-exao/i03-boutons.md
@@ -25,7 +25,7 @@ sidebar_position: 10
 - 1 carte STeaMi
 - 1 câble USB de données (micro-USB pour la STeaMi V1, USB-C pour la STeaMi V2).
 - 1 ordinateur sous Windows, macOS ou Linux
-- Un IDE compatible MicroPython : Thonny (voir la fiche [Thonny : Prise en main de MicroPython](/ressources/inovmicro-exao/t03-decouverte-thonny)) ou tout autre éditeur compatible (Mu, VS Code, Vittascience, `mpremote`...).
+- Un IDE compatible MicroPython : Thonny (voir la fiche [Prendre en main MicroPython avec Thonny](/ressources/inovmicro-exao/t03-decouverte-thonny)) ou tout autre éditeur compatible (Mu, VS Code, Vittascience, `mpremote`...).
 
 <PdfLink href="/pdf/inovmicro-exao/STeaMi_Boutons.pdf">Télécharger en PDF</PdfLink>
 
@@ -99,7 +99,7 @@ Sur la STeaMi, cette résistance (4,7 kΩ) relie chaque broche de bouton à l'al
 
 ### 2. Connecter la carte à l'ordinateur
 
-Brancher la STeaMi à l'ordinateur via le câble USB. Si l'IDE est déjà configuré (voir la fiche [Thonny : Prise en main de MicroPython](/ressources/inovmicro-exao/t03-decouverte-thonny) si vous démarrez), la console MicroPython doit afficher `>>>`. C'est **l'invite** (parfois appelée « prompt » en anglais) : un signe qui apparaît en début de ligne pour vous dire que la console est prête à recevoir une commande.
+Brancher la STeaMi à l'ordinateur via le câble USB. Si l'IDE est déjà configuré (voir la fiche [Prendre en main MicroPython avec Thonny](/ressources/inovmicro-exao/t03-decouverte-thonny) si vous démarrez), la console MicroPython doit afficher `>>>`. C'est **l'invite** (parfois appelée « prompt » en anglais) : un signe qui apparaît en début de ligne pour vous dire que la console est prête à recevoir une commande.
 
 ### 3. Lancer le programme
 

--- a/site/docs/inovmicro-exao/i04-capteur-lumiere.md
+++ b/site/docs/inovmicro-exao/i04-capteur-lumiere.md
@@ -1,13 +1,13 @@
 ---
 id: i04-capteur-lumiere
-title: Capteur de lumière avec la STeaMi
-sidebar_label: "Capteur de lumière"
+title: Mesurer la lumière ambiante
+sidebar_label: "Mesurer la lumière"
 sidebar_position: 11
 ---
 
 <div style={{display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: '2rem', marginBottom: '1.5rem'}}>
 <div style={{flex: 1}}>
-# Capteur de lumière avec la STeaMi
+# Mesurer la lumière ambiante
 
 <div style={{display: 'flex', gap: '0.5rem', flexWrap: 'wrap', marginBottom: '1rem'}}>
   <span className="badge badge--primary">Informatique</span>
@@ -26,7 +26,7 @@ sidebar_position: 11
 - 1 carte STeaMi
 - 1 câble USB de données (micro-USB pour la STeaMi V1, USB-C pour la STeaMi V2).
 - 1 ordinateur sous Windows, macOS ou Linux
-- Un IDE MicroPython installé et configuré pour la STeaMi. Voir la fiche [Thonny : Prise en main de MicroPython](/ressources/inovmicro-exao/t03-decouverte-thonny) pour la mise en place, tout autre éditeur compatible MicroPython (Mu, VS Code, Vittascience, `mpremote`...) fonctionne aussi.
+- Un IDE MicroPython installé et configuré pour la STeaMi. Voir la fiche [Prendre en main MicroPython avec Thonny](/ressources/inovmicro-exao/t03-decouverte-thonny) pour la mise en place, tout autre éditeur compatible MicroPython (Mu, VS Code, Vittascience, `mpremote`...) fonctionne aussi.
 <PdfLink href="/pdf/inovmicro-exao/STeaMi_Lumiere.pdf">Télécharger en PDF</PdfLink>
 
 </div>
@@ -82,7 +82,7 @@ Contrairement à une photorésistance qui fournit une tension variable lue par u
 
 ### 2. Connecter la carte à l'ordinateur
 
-Brancher la STeaMi à l'ordinateur via le câble USB. Si votre IDE MicroPython est déjà configuré (voir la fiche [Thonny : Prise en main de MicroPython](/ressources/inovmicro-exao/t03-decouverte-thonny) si vous démarrez), la console MicroPython doit afficher `>>>`. C'est **l'invite** (parfois appelée « prompt » en anglais) : un signe qui apparaît en début de ligne pour vous dire que la console est prête à recevoir une commande.
+Brancher la STeaMi à l'ordinateur via le câble USB. Si votre IDE MicroPython est déjà configuré (voir la fiche [Prendre en main MicroPython avec Thonny](/ressources/inovmicro-exao/t03-decouverte-thonny) si vous démarrez), la console MicroPython doit afficher `>>>`. C'est **l'invite** (parfois appelée « prompt » en anglais) : un signe qui apparaît en début de ligne pour vous dire que la console est prête à recevoir une commande.
 
 ### 3. Vérifier que le capteur répond
 

--- a/site/docs/inovmicro-exao/i05-potentiometre.md
+++ b/site/docs/inovmicro-exao/i05-potentiometre.md
@@ -211,7 +211,7 @@ Imaginer un usage qui sorte du « variateur de lumière ». Pistes :
 - Un **contrôleur de température cible** d'un thermostat (la position du bouton fixe une consigne, comparée à la température lue sur le HTS221 intégré à la STeaMi).
 - Une **manette analogique** pour un mini-jeu sur l'écran OLED : la position du curseur déplace un sprite horizontalement.
 - Un **prototype de jauge** où le potentiomètre simule le niveau d'essence d'une voiture et la LED s'allume rouge quand on passe en réserve.
-- Un **doseur** virtuel : on tourne le bouton pour fixer une durée (entre 1 et 10 minutes), un buzzer sonne à la fin (en combinaison avec la fiche [Minuteur électronique](/ressources/inovmicro-exao/i14-minuteur-electronique)).
+- Un **doseur** virtuel : on tourne le bouton pour fixer une durée (entre 1 et 10 minutes), un buzzer sonne à la fin (en combinaison avec la fiche [Fabriquer un minuteur électronique](/ressources/inovmicro-exao/i14-minuteur-electronique)).
 
 ---
 

--- a/site/docs/inovmicro-exao/i06-code-morse.md
+++ b/site/docs/inovmicro-exao/i06-code-morse.md
@@ -1,13 +1,13 @@
 ---
 id: i06-code-morse
-title: Envoyer des messages en code Morse avec la STeaMi
+title: Envoyer des messages en code Morse
 sidebar_label: "Code Morse"
 sidebar_position: 13
 ---
 
 <div style={{display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: '2rem', marginBottom: '1.5rem'}}>
 <div style={{flex: 1}}>
-# Envoyer des messages en code Morse avec la STeaMi
+# Envoyer des messages en code Morse
 
 <div style={{display: 'flex', gap: '0.5rem', flexWrap: 'wrap', marginBottom: '1rem'}}>
   <span className="badge badge--primary">Informatique</span>
@@ -25,7 +25,7 @@ sidebar_position: 13
 - 1 carte STeaMi
 - 1 câble USB de données (micro-USB pour la STeaMi V1, USB-C pour la STeaMi V2).
 - 1 ordinateur sous Windows, macOS ou Linux
-- Un IDE compatible MicroPython : Thonny (voir la fiche [Thonny : Prise en main de MicroPython](/ressources/inovmicro-exao/t03-decouverte-thonny)) ou tout autre éditeur compatible (Mu, VS Code, Vittascience, `mpremote`...).
+- Un IDE compatible MicroPython : Thonny (voir la fiche [Prendre en main MicroPython avec Thonny](/ressources/inovmicro-exao/t03-decouverte-thonny)) ou tout autre éditeur compatible (Mu, VS Code, Vittascience, `mpremote`...).
 
 <PdfLink href="/pdf/inovmicro-exao/STeaMi_Morse.pdf">Télécharger en PDF</PdfLink>
 

--- a/site/docs/inovmicro-exao/i07-musique.md
+++ b/site/docs/inovmicro-exao/i07-musique.md
@@ -27,7 +27,7 @@ import ABCNotation from '@site/src/components/ABCNotation';
 - 1 carte STeaMi
 - 1 câble USB de données (micro-USB pour la STeaMi V1, USB-C pour la STeaMi V2).
 - 1 ordinateur sous Windows, macOS ou Linux
-- Un IDE compatible MicroPython : Thonny (voir la fiche [Thonny : Prise en main de MicroPython](/ressources/inovmicro-exao/t03-decouverte-thonny)) ou tout autre éditeur compatible (Mu, VS Code, Vittascience, `mpremote`...).
+- Un IDE compatible MicroPython : Thonny (voir la fiche [Prendre en main MicroPython avec Thonny](/ressources/inovmicro-exao/t03-decouverte-thonny)) ou tout autre éditeur compatible (Mu, VS Code, Vittascience, `mpremote`...).
 
 </div>
 <img src="/img/ressources/inovmicro-exao/i07-musique/icone.png" alt="Composer une mélodie sur la STeaMi" style={{width: '225px', height: '225px', objectFit: 'contain', flexShrink: 0}} />
@@ -116,7 +116,7 @@ Les deux Do (ou les deux Ré, etc.) sont la même note à une octave d'écart : 
 
 ### 4. Connecter la carte à l'ordinateur
 
-Brancher la STeaMi à l'ordinateur via le câble USB. Si l'IDE est déjà configuré (voir la fiche [Thonny : Prise en main de MicroPython](/ressources/inovmicro-exao/t03-decouverte-thonny) si vous démarrez), la console MicroPython doit afficher `>>>`. C'est **l'invite** (parfois appelée « prompt » en anglais) : un signe qui apparaît en début de ligne pour vous dire que la console est prête à recevoir une commande.
+Brancher la STeaMi à l'ordinateur via le câble USB. Si l'IDE est déjà configuré (voir la fiche [Prendre en main MicroPython avec Thonny](/ressources/inovmicro-exao/t03-decouverte-thonny) si vous démarrez), la console MicroPython doit afficher `>>>`. C'est **l'invite** (parfois appelée « prompt » en anglais) : un signe qui apparaît en début de ligne pour vous dire que la console est prête à recevoir une commande.
 
 ### 5. Lancer le programme
 
@@ -526,7 +526,7 @@ Au lieu d'une seule mélodie en boucle, en stocker plusieurs dans des listes dif
 
 ### 3. Coder un message en Morse
 
-Avec le même buzzer, on peut produire des points et des tirets pour transmettre un message en code Morse. La fiche [Envoyer des messages en code Morse avec la STeaMi](/ressources/inovmicro-exao/i06-code-morse) explore cette piste en détail.
+Avec le même buzzer, on peut produire des points et des tirets pour transmettre un message en code Morse. La fiche [Envoyer des messages en code Morse](/ressources/inovmicro-exao/i06-code-morse) explore cette piste en détail.
 
 ### 4. Mélodie au rythme d'un capteur (bonus)
 

--- a/site/docs/inovmicro-exao/i08-theremine.md
+++ b/site/docs/inovmicro-exao/i08-theremine.md
@@ -27,7 +27,7 @@ sidebar_position: 8
 - 1 carte STeaMi
 - 1 câble USB de données (micro-USB pour la STeaMi V1, USB-C pour la STeaMi V2). Attention : un câble qui ne sert qu'à charger un téléphone ne fonctionnera pas.
 - 1 ordinateur sous Windows, macOS ou Linux
-- Un IDE compatible MicroPython : Thonny (voir la fiche [Thonny : Prise en main de MicroPython](/ressources/inovmicro-exao/t03-decouverte-thonny)) ou tout autre éditeur compatible (Mu, VS Code, Vittascience, `mpremote`...).
+- Un IDE compatible MicroPython : Thonny (voir la fiche [Prendre en main MicroPython avec Thonny](/ressources/inovmicro-exao/t03-decouverte-thonny)) ou tout autre éditeur compatible (Mu, VS Code, Vittascience, `mpremote`...).
 
 </div>
 <img src="/img/ressources/inovmicro-exao/i08-theremine/icone.png" alt="Thérémine sur la STeaMi" style={{width: '225px', height: '225px', objectFit: 'contain', flexShrink: 0}} />
@@ -124,7 +124,7 @@ Les fréquences 440 Hz et 880 Hz ne sont pas choisies au hasard : 880 = 2 × 440
 
 ### Connecter la carte à l'ordinateur
 
-Brancher la STeaMi à l'ordinateur via le câble USB. Si un des IDE proposés est déjà configuré (voir la fiche [Thonny : Prise en main de MicroPython](/ressources/inovmicro-exao/t03-decouverte-thonny) si vous démarrez), la console MicroPython doit afficher `>>>`. C'est **l'invite** (parfois appelée « prompt » en anglais) : un signe qui apparaît en début de ligne pour vous dire que la console est prête à recevoir une commande.
+Brancher la STeaMi à l'ordinateur via le câble USB. Si un des IDE proposés est déjà configuré (voir la fiche [Prendre en main MicroPython avec Thonny](/ressources/inovmicro-exao/t03-decouverte-thonny) si vous démarrez), la console MicroPython doit afficher `>>>`. C'est **l'invite** (parfois appelée « prompt » en anglais) : un signe qui apparaît en début de ligne pour vous dire que la console est prête à recevoir une commande.
 
 ### Tester le capteur dans l'invite
 

--- a/site/docs/inovmicro-exao/i09-inclinaison-accelerometre.md
+++ b/site/docs/inovmicro-exao/i09-inclinaison-accelerometre.md
@@ -1,13 +1,13 @@
 ---
 id: i09-inclinaison-accelerometre
-title: Inclinaison avec accéléromètre
-sidebar_label: "Inclinaison avec accéléromètre"
+title: Mesurer l'inclinaison avec l'accéléromètre
+sidebar_label: "Mesurer l'inclinaison avec l'accéléromètre"
 sidebar_position: 9
 ---
 
 <div style={{display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: '2rem', marginBottom: '1.5rem'}}>
 <div style={{flex: 1}}>
-# Inclinaison avec accéléromètre
+# Mesurer l'inclinaison avec l'accéléromètre
 
 <div style={{display: 'flex', gap: '0.5rem', flexWrap: 'wrap', marginBottom: '1rem'}}>
   <span className="badge badge--primary">Informatique</span>
@@ -26,7 +26,7 @@ sidebar_position: 9
 - 1 carte STeaMi
 - 1 câble USB de données (micro-USB pour la STeaMi V1, USB-C pour la STeaMi V2)
 - 1 ordinateur sous Windows, macOS ou Linux
-- Un IDE compatible MicroPython : Thonny (voir la fiche [Thonny : Prise en main de MicroPython](/ressources/inovmicro-exao/t03-decouverte-thonny)) ou tout autre éditeur compatible (Mu, VS Code, Vittascience, `mpremote`...).
+- Un IDE compatible MicroPython : Thonny (voir la fiche [Prendre en main MicroPython avec Thonny](/ressources/inovmicro-exao/t03-decouverte-thonny)) ou tout autre éditeur compatible (Mu, VS Code, Vittascience, `mpremote`...).
 
 </div>
 <img src="/img/ressources/inovmicro-exao/i09-inclinaison-accelerometre/icone.png" alt="Inclinaison avec accéléromètre sur la STeaMi" style={{width: '225px', height: '225px', objectFit: 'contain', flexShrink: 0}} />
@@ -115,7 +115,7 @@ if abs(acceleration_x) > 0.5:
 
 ### Connecter la carte à l'ordinateur
 
-Brancher la STeaMi à l'ordinateur via le câble USB. Si l'IDE est déjà configuré (voir la fiche [Thonny : Prise en main de MicroPython](/ressources/inovmicro-exao/t03-decouverte-thonny) si vous démarrez), la console MicroPython doit afficher `>>>`. C'est **l'invite** (parfois appelée « prompt » en anglais) : un signe qui apparaît en début de ligne pour vous dire que la console est prête à recevoir une commande.
+Brancher la STeaMi à l'ordinateur via le câble USB. Si l'IDE est déjà configuré (voir la fiche [Prendre en main MicroPython avec Thonny](/ressources/inovmicro-exao/t03-decouverte-thonny) si vous démarrez), la console MicroPython doit afficher `>>>`. C'est **l'invite** (parfois appelée « prompt » en anglais) : un signe qui apparaît en début de ligne pour vous dire que la console est prête à recevoir une commande.
 
 ### Tester le capteur dans l'invite
 

--- a/site/docs/inovmicro-exao/i10-texte-oled.md
+++ b/site/docs/inovmicro-exao/i10-texte-oled.md
@@ -25,7 +25,7 @@ sidebar_position: 17
 - 1 carte STeaMi
 - 1 câble USB de données (micro-USB pour la STeaMi V1, USB-C pour la STeaMi V2).
 - 1 ordinateur sous Windows, macOS ou Linux
-- Un IDE compatible MicroPython : Thonny (voir la fiche [Thonny : Prise en main de MicroPython](/ressources/inovmicro-exao/t03-decouverte-thonny)) ou tout autre éditeur compatible (Mu, VS Code, Vittascience, `mpremote`...).
+- Un IDE compatible MicroPython : Thonny (voir la fiche [Prendre en main MicroPython avec Thonny](/ressources/inovmicro-exao/t03-decouverte-thonny)) ou tout autre éditeur compatible (Mu, VS Code, Vittascience, `mpremote`...).
 
 <PdfLink href="/pdf/inovmicro-exao/STeaMi_Ecran.pdf">Télécharger en PDF</PdfLink>
 
@@ -58,7 +58,7 @@ Sur la STeaMi, l'écran est déjà câblé en interne, il n'y a aucun montage ex
 
 ### 1. Connecter la carte à l'ordinateur
 
-Brancher la STeaMi avec son câble USB (micro-USB sur la STeaMi V1, USB-C sur la STeaMi V2). Un nouveau lecteur appelé `STEAMI` apparaît sur l'ordinateur. Si l'IDE est déjà configuré (voir la fiche [Thonny : Prise en main de MicroPython](/ressources/inovmicro-exao/t03-decouverte-thonny) si vous démarrez), la console MicroPython doit afficher `>>>`. C'est **l'invite** (parfois appelée « prompt » en anglais) : un signe qui apparaît en début de ligne pour vous dire que la console est prête à recevoir une commande.
+Brancher la STeaMi avec son câble USB (micro-USB sur la STeaMi V1, USB-C sur la STeaMi V2). Un nouveau lecteur appelé `STEAMI` apparaît sur l'ordinateur. Si l'IDE est déjà configuré (voir la fiche [Prendre en main MicroPython avec Thonny](/ressources/inovmicro-exao/t03-decouverte-thonny) si vous démarrez), la console MicroPython doit afficher `>>>`. C'est **l'invite** (parfois appelée « prompt » en anglais) : un signe qui apparaît en début de ligne pour vous dire que la console est prête à recevoir une commande.
 
 <figure style={{textAlign: 'center', margin: '1rem auto'}}>
   <img

--- a/site/docs/inovmicro-exao/i11-thermometre-lisible.md
+++ b/site/docs/inovmicro-exao/i11-thermometre-lisible.md
@@ -1,13 +1,13 @@
 ---
 id: i11-thermometre-lisible
-title: Thermomètre très lisible
-sidebar_label: "Thermomètre très lisible"
+title: Afficher un thermomètre très lisible
+sidebar_label: "Afficher un thermomètre très lisible"
 sidebar_position: 11
 ---
 
 <div style={{display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: '2rem', marginBottom: '1.5rem'}}>
 <div style={{flex: 1}}>
-# Thermomètre très lisible
+# Afficher un thermomètre très lisible
 
 <div style={{display: 'flex', gap: '0.5rem', flexWrap: 'wrap', marginBottom: '1rem'}}>
   <span className="badge badge--primary">Informatique</span>
@@ -26,7 +26,7 @@ sidebar_position: 11
 - 1 carte STeaMi
 - 1 câble USB de données (micro-USB pour la STeaMi V1, USB-C pour la STeaMi V2)
 - 1 ordinateur sous Windows, macOS ou Linux
-- Un IDE compatible MicroPython : Thonny (voir la fiche [Thonny : Prise en main de MicroPython](/ressources/inovmicro-exao/t03-decouverte-thonny)) ou tout autre éditeur compatible (Mu, VS Code, Vittascience, `mpremote`...).
+- Un IDE compatible MicroPython : Thonny (voir la fiche [Prendre en main MicroPython avec Thonny](/ressources/inovmicro-exao/t03-decouverte-thonny)) ou tout autre éditeur compatible (Mu, VS Code, Vittascience, `mpremote`...).
 
 </div>
 <img src="/img/ressources/inovmicro-exao/i11-thermometre-lisible/icone.png" alt="Thermomètre très lisible sur la STeaMi" style={{width: '225px', height: '225px', objectFit: 'contain', flexShrink: 0}} />
@@ -128,7 +128,7 @@ ecran = Screen(pilote_oled)
 
 ### Connecter la carte à l'ordinateur
 
-Brancher la STeaMi à l'ordinateur via le câble USB. Si l'IDE est déjà configuré (voir la fiche [Thonny : Prise en main de MicroPython](/ressources/inovmicro-exao/t03-decouverte-thonny) si vous démarrez), la console MicroPython doit afficher `>>>`. C'est **l'invite** (parfois appelée « prompt » en anglais) : un signe qui apparaît en début de ligne pour vous dire que la console est prête à recevoir une commande.
+Brancher la STeaMi à l'ordinateur via le câble USB. Si l'IDE est déjà configuré (voir la fiche [Prendre en main MicroPython avec Thonny](/ressources/inovmicro-exao/t03-decouverte-thonny) si vous démarrez), la console MicroPython doit afficher `>>>`. C'est **l'invite** (parfois appelée « prompt » en anglais) : un signe qui apparaît en début de ligne pour vous dire que la console est prête à recevoir une commande.
 
 ### Tester le capteur dans l'invite
 

--- a/site/docs/inovmicro-exao/i12-alarme-mouvement.md
+++ b/site/docs/inovmicro-exao/i12-alarme-mouvement.md
@@ -1,7 +1,7 @@
 ---
 id: i12-alarme-mouvement
-title: Alarme de mouvement
-sidebar_label: 'Alarme de mouvement'
+title: Créer une alarme de mouvement
+sidebar_label: 'Créer une alarme de mouvement'
 sidebar_position: 12
 ---
 
@@ -9,7 +9,7 @@ sidebar_position: 12
 
 <div style={{flex: 1}}>
 
-# Alarme de mouvement
+# Créer une alarme de mouvement
 
 <div style={{display: 'flex', gap: '0.5rem', flexWrap: 'wrap', marginBottom: '1rem'}}>
   <span className="badge badge--primary">Informatique</span>
@@ -28,7 +28,7 @@ sidebar_position: 12
 - 1 carte STeaMi
 - 1 câble USB de données (micro-USB pour la STeaMi V1, USB-C pour la STeaMi V2)
 - 1 ordinateur sous Windows, macOS ou Linux
-- Un IDE compatible MicroPython : Thonny (voir la fiche [Thonny : Prise en main de MicroPython](/ressources/inovmicro-exao/t03-decouverte-thonny)) ou tout autre éditeur compatible (Mu, VS Code, Vittascience, `mpremote`...).
+- Un IDE compatible MicroPython : Thonny (voir la fiche [Prendre en main MicroPython avec Thonny](/ressources/inovmicro-exao/t03-decouverte-thonny)) ou tout autre éditeur compatible (Mu, VS Code, Vittascience, `mpremote`...).
 
 </div>
 
@@ -50,7 +50,7 @@ La STeaMi embarque deux capteurs qui permettent de détecter le mouvement de deu
 Dans cette activité, on combine les deux pour fabriquer une **alarme à double protection** : la STeaMi sonne soit si on la déplace, soit si une main s'approche d'elle. On utilise le bouton Menu pour armer ou désarmer l'alarme, comme une vraie alarme de maison.
 
 :::info[Capteurs intégrés, rien à câbler]
-L'accéléromètre et le capteur de distance sont déjà soudés à la STeaMi. On n'a rien à brancher : il suffit de les appeler depuis le code. Voir les fiches [Fabriquer un thérémine](/ressources/inovmicro-exao/i08-theremine) (capteur de distance) et [Inclinaison avec accéléromètre](/ressources/inovmicro-exao/i09-inclinaison-accelerometre) pour découvrir chaque capteur en détail.
+L'accéléromètre et le capteur de distance sont déjà soudés à la STeaMi. On n'a rien à brancher : il suffit de les appeler depuis le code. Voir les fiches [Fabriquer un thérémine](/ressources/inovmicro-exao/i08-theremine) (capteur de distance) et [Mesurer l'inclinaison avec l'accéléromètre](/ressources/inovmicro-exao/i09-inclinaison-accelerometre) pour découvrir chaque capteur en détail.
 :::
 
 ---
@@ -105,7 +105,7 @@ La STeaMi possède un bouton noté **Menu** en plus des boutons A et B. On va s'
 
 ### Connecter la carte à l'ordinateur
 
-Branchez la STeaMi à l'ordinateur via le câble USB. Si votre IDE MicroPython est déjà configuré (voir la fiche [Thonny : Prise en main de MicroPython](/ressources/inovmicro-exao/t03-decouverte-thonny) si vous démarrez), la console MicroPython doit afficher `>>>`. C'est **l'invite** (parfois appelée « prompt » en anglais) : un signe qui apparaît en début de ligne pour vous dire que la console est prête à recevoir une commande.
+Branchez la STeaMi à l'ordinateur via le câble USB. Si votre IDE MicroPython est déjà configuré (voir la fiche [Prendre en main MicroPython avec Thonny](/ressources/inovmicro-exao/t03-decouverte-thonny) si vous démarrez), la console MicroPython doit afficher `>>>`. C'est **l'invite** (parfois appelée « prompt » en anglais) : un signe qui apparaît en début de ligne pour vous dire que la console est prête à recevoir une commande.
 
 ---
 

--- a/site/docs/inovmicro-exao/i14-minuteur-electronique.md
+++ b/site/docs/inovmicro-exao/i14-minuteur-electronique.md
@@ -1,13 +1,13 @@
 ---
 id: i14-minuteur-electronique
-title: Minuteur électronique
-sidebar_label: "Minuteur électronique"
+title: Fabriquer un minuteur électronique
+sidebar_label: "Fabriquer un minuteur électronique"
 sidebar_position: 14
 ---
 
 <div style={{display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: '2rem', marginBottom: '1.5rem'}}>
 <div style={{flex: 1}}>
-# Minuteur électronique
+# Fabriquer un minuteur électronique
 
 <div style={{display: 'flex', gap: '0.5rem', flexWrap: 'wrap', marginBottom: '1rem'}}>
   <span className="badge badge--primary">Informatique</span>
@@ -25,7 +25,7 @@ sidebar_position: 14
 - 1 carte STeaMi
 - 1 câble USB de données (micro-USB pour la STeaMi V1, USB-C pour la STeaMi V2)
 - 1 ordinateur sous Windows, macOS ou Linux
-- Un IDE compatible MicroPython : Thonny (voir la fiche [Thonny : Prise en main de MicroPython](/ressources/inovmicro-exao/t03-decouverte-thonny)) ou tout autre éditeur compatible (Mu, VS Code, Vittascience, `mpremote`...).
+- Un IDE compatible MicroPython : Thonny (voir la fiche [Prendre en main MicroPython avec Thonny](/ressources/inovmicro-exao/t03-decouverte-thonny)) ou tout autre éditeur compatible (Mu, VS Code, Vittascience, `mpremote`...).
 
 </div>
 <img src="/img/ressources/inovmicro-exao/i14-minuteur-electronique/icone.png" alt="Minuteur électronique sur la STeaMi" style={{width: '225px', height: '225px', objectFit: 'contain', flexShrink: 0}} />
@@ -165,7 +165,7 @@ while True:
 
 ### Connecter la carte à l'ordinateur
 
-Brancher la STeaMi à l'ordinateur via le câble USB. Si l'IDE est déjà configuré (voir la fiche [Thonny : Prise en main de MicroPython](/ressources/inovmicro-exao/t03-decouverte-thonny) si vous démarrez), la console MicroPython doit afficher `>>>`. C'est **l'invite** (parfois appelée « prompt » en anglais) : un signe qui apparaît en début de ligne pour vous dire que la console est prête à recevoir une commande.
+Brancher la STeaMi à l'ordinateur via le câble USB. Si l'IDE est déjà configuré (voir la fiche [Prendre en main MicroPython avec Thonny](/ressources/inovmicro-exao/t03-decouverte-thonny) si vous démarrez), la console MicroPython doit afficher `>>>`. C'est **l'invite** (parfois appelée « prompt » en anglais) : un signe qui apparaît en début de ligne pour vous dire que la console est prête à recevoir une commande.
 
 ---
 

--- a/site/docs/inovmicro-exao/i15-collecter-donnees.md
+++ b/site/docs/inovmicro-exao/i15-collecter-donnees.md
@@ -26,7 +26,7 @@ sidebar_position: 15
 - 1 carte STeaMi
 - 1 câble USB de données (micro-USB pour la STeaMi V1, USB-C pour la STeaMi V2)
 - 1 ordinateur sous Windows, macOS ou Linux
-- Un IDE compatible MicroPython : Thonny (voir la fiche [Thonny : Prise en main de MicroPython](/ressources/inovmicro-exao/t03-decouverte-thonny)) ou tout autre éditeur compatible (Mu, VS Code, Vittascience, `mpremote`...).
+- Un IDE compatible MicroPython : Thonny (voir la fiche [Prendre en main MicroPython avec Thonny](/ressources/inovmicro-exao/t03-decouverte-thonny)) ou tout autre éditeur compatible (Mu, VS Code, Vittascience, `mpremote`...).
 - Un tableur (Google Sheets, LibreOffice Calc, Microsoft Excel...)
 
 </div>
@@ -118,7 +118,7 @@ ecoule_s = time.ticks_diff(time.ticks_ms(), debut) // 1000
 
 ### Connecter la carte à l'ordinateur
 
-Brancher la STeaMi à l'ordinateur via le câble USB. Si l'IDE est déjà configuré (voir la fiche [Thonny : Prise en main de MicroPython](/ressources/inovmicro-exao/t03-decouverte-thonny) si vous démarrez), la console MicroPython doit afficher `>>>`. C'est **l'invite** (parfois appelée « prompt » en anglais) : un signe qui apparaît en début de ligne pour vous dire que la console est prête à recevoir une commande.
+Brancher la STeaMi à l'ordinateur via le câble USB. Si l'IDE est déjà configuré (voir la fiche [Prendre en main MicroPython avec Thonny](/ressources/inovmicro-exao/t03-decouverte-thonny) si vous démarrez), la console MicroPython doit afficher `>>>`. C'est **l'invite** (parfois appelée « prompt » en anglais) : un signe qui apparaît en début de ligne pour vous dire que la console est prête à recevoir une commande.
 
 ### Tester les capteurs dans l'invite
 
@@ -454,7 +454,7 @@ Les capteurs de la STeaMi sont précis, mais ils mesurent **au niveau de la cart
 - **Auto-échauffement** : l'électronique en marche dégage un peu de chaleur. Si la carte est posée au contact de l'air froid d'un frigo, le capteur indique souvent 1 à 3 °C de plus que la température réelle au centre du frigo.
 - **Emplacement** : poser la carte près de la porte du frigo, c'est mesurer l'air qui rentre à chaque ouverture, pas la zone froide du fond. La même pièce peut afficher 18 °C près d'une fenêtre et 23 °C près d'un radiateur.
 
-Pour rester scientifique : **compare toujours à un thermomètre de référence** (médical, station météo, thermomètre de cuisine, thermomètre du frigo si disponible) pendant 5 minutes au début de l'expérience. Note l'écart constant entre les deux, et corrige tes valeurs après coup. C'est exactement ce que fait la fiche [Thermomètre très lisible](/ressources/inovmicro-exao/i11-thermometre-lisible) avec `set_temp_offset()`.
+Pour rester scientifique : **compare toujours à un thermomètre de référence** (médical, station météo, thermomètre de cuisine, thermomètre du frigo si disponible) pendant 5 minutes au début de l'expérience. Note l'écart constant entre les deux, et corrige tes valeurs après coup. C'est exactement ce que fait la fiche [Afficher un thermomètre très lisible](/ressources/inovmicro-exao/i11-thermometre-lisible) avec `set_temp_offset()`.
 
 Et surtout : un capteur de température ne te dira **jamais** si ton frigo est conforme aux normes de sécurité alimentaire. Pour ça, il faut un thermomètre certifié et savoir où poser la sonde. Notre mesure est utile pour **explorer**, pas pour **certifier**.
 

--- a/site/docs/inovmicro-exao/t03-decouverte-thonny.md
+++ b/site/docs/inovmicro-exao/t03-decouverte-thonny.md
@@ -1,13 +1,13 @@
 ---
 id: t03-decouverte-thonny
-title: "Thonny : Prise en main de MicroPython sur la STeaMi"
+title: "Prendre en main MicroPython avec Thonny"
 sidebar_label: "Thonny"
 sidebar_position: 3
 ---
 
 <div style={{display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: '2rem', marginBottom: '1.5rem'}}>
 <div style={{flex: 1}}>
-# Thonny : Prise en main de MicroPython sur la STeaMi
+# Prendre en main MicroPython avec Thonny
 <div style={{display: 'flex', gap: '0.5rem', flexWrap: 'wrap', marginBottom: '1rem'}}>
   <span className="badge badge--primary">Informatique</span>
   <span className="badge badge--primary">Technologie</span>
@@ -365,7 +365,7 @@ Le debugger Thonny est plus efficace en local sur le PC qu'en cible embarquée. 
 
 ### Dépanner les erreurs courantes
 
-La plupart des problèmes rencontrés en classe ne sont pas spécifiques à Thonny mais touchent le matériel ou l'environnement MicroPython (câble, port série, programme bloqué). Ils sont regroupés sur la page transverse [Dépannage STeaMi](/ressources/inovmicro-exao/depannage), qui couvre :
+La plupart des problèmes rencontrés en classe ne sont pas spécifiques à Thonny mais touchent le matériel ou l'environnement MicroPython (câble, port série, programme bloqué). Ils sont regroupés sur la page transverse [Dépanner la STeaMi](/ressources/inovmicro-exao/depannage), qui couvre :
 
 - la carte qui n'apparaît pas comme disque `STEAMI` (câble) ;
 - le port série introuvable ou avec accès refusé (Windows / Linux) ;

--- a/site/docs/inovmicro-exao/t04-vscode.md
+++ b/site/docs/inovmicro-exao/t04-vscode.md
@@ -1,13 +1,13 @@
 ---
 id: t04-vscode
-title: "VS Code : Prise en main de MicroPython sur la STeaMi"
+title: "Prendre en main MicroPython avec VS Code"
 sidebar_label: "VS Code"
 sidebar_position: 4
 ---
 
 <div style={{display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: '2rem', marginBottom: '1.5rem'}}>
 <div style={{flex: 1}}>
-# VS Code : Prise en main de MicroPython sur la STeaMi
+# Prendre en main MicroPython avec VS Code
 <div style={{display: 'flex', gap: '0.5rem', flexWrap: 'wrap', marginBottom: '1rem'}}>
   <span className="badge badge--primary">Informatique</span>
   <span className="badge badge--primary">Technologie</span>
@@ -254,7 +254,7 @@ Si un programme est déjà en cours d'exécution sur la STeaMi et empêche d'ex�
 :::
 
 :::info[Sous Linux : `Permission denied` sur `/dev/ttyACM*`]
-Si `mpremote connect auto` répond une erreur de permission, il faut ajouter le compte au groupe `dialout` (commande détaillée dans la fiche [Dépannage STeaMi](/ressources/inovmicro-exao/depannage)), puis se déconnecter / reconnecter à la session.
+Si `mpremote connect auto` répond une erreur de permission, il faut ajouter le compte au groupe `dialout` (commande détaillée dans la fiche [Dépanner la STeaMi](/ressources/inovmicro-exao/depannage)), puis se déconnecter / reconnecter à la session.
 :::
 
 ---
@@ -343,7 +343,7 @@ Les modules **spécifiques à la STeaMi** (`steami_screen`, `ism330dl`, `mcp2300
 
 ### Dépanner les erreurs courantes
 
-La plupart des problèmes rencontrés ne sont pas spécifiques à VS Code mais touchent le matériel ou l'environnement MicroPython (câble, port série, programme bloqué). Ils sont regroupés sur la page transverse [Dépannage STeaMi](/ressources/inovmicro-exao/depannage), qui couvre :
+La plupart des problèmes rencontrés ne sont pas spécifiques à VS Code mais touchent le matériel ou l'environnement MicroPython (câble, port série, programme bloqué). Ils sont regroupés sur la page transverse [Dépanner la STeaMi](/ressources/inovmicro-exao/depannage), qui couvre :
 
 - la carte qui n'apparaît pas comme disque `STEAMI` (câble) ;
 - le port série introuvable ou avec accès refusé (Windows / Linux) ;

--- a/site/docs/inovmicro-exao/t05-vittascience.md
+++ b/site/docs/inovmicro-exao/t05-vittascience.md
@@ -1,6 +1,6 @@
 ---
 id: t05-vittascience
-title: "Vittascience : Prise en main de MicroPython et blocs sur la STeaMi"
+title: "Prendre en main la STeaMi sur l'éditeur Vittascience"
 sidebar_label: "Vittascience"
 sidebar_position: 5
 ---
@@ -8,7 +8,7 @@ sidebar_position: 5
 <div style={{display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: '2rem', marginBottom: '1.5rem'}}>
 <div style={{flex: 1}}>
 
-# Vittascience : Prise en main de MicroPython et blocs sur la STeaMi
+# Prendre en main la STeaMi sur l'éditeur Vittascience
 
 <div style={{display: 'flex', gap: '0.5rem', flexWrap: 'wrap', marginBottom: '1rem'}}>
   <span className="badge badge--primary">Informatique</span>
@@ -270,7 +270,7 @@ Le REPL de Vittascience web utilise la **Web Serial API**, disponible uniquement
 
 ### Dépanner les erreurs courantes
 
-La plupart des problèmes rencontrés ne sont pas spécifiques à Vittascience mais touchent le matériel ou l'environnement MicroPython (câble, port série, programme bloqué). Ils sont regroupés sur la page transverse [Dépannage STeaMi](/ressources/inovmicro-exao/depannage), qui couvre :
+La plupart des problèmes rencontrés ne sont pas spécifiques à Vittascience mais touchent le matériel ou l'environnement MicroPython (câble, port série, programme bloqué). Ils sont regroupés sur la page transverse [Dépanner la STeaMi](/ressources/inovmicro-exao/depannage), qui couvre :
 
 - la carte qui n'apparaît pas comme disque `STEAMI` (câble) ;
 - le port série introuvable ou avec accès refusé (Windows / Linux) ;

--- a/site/docs/inovmicro-exao/t06-bases-micropython.md
+++ b/site/docs/inovmicro-exao/t06-bases-micropython.md
@@ -1,13 +1,13 @@
 ---
 id: t06-bases-micropython
-title: "Bases du langage : Prise en main de MicroPython"
+title: "Découvrir les bases de MicroPython"
 sidebar_label: "Bases du langage"
 sidebar_position: 6
 ---
 
 <div style={{display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: '2rem', marginBottom: '1.5rem'}}>
 <div style={{flex: 1}}>
-# Bases du langage : Prise en main de MicroPython
+# Découvrir les bases de MicroPython
 <div style={{display: 'flex', gap: '0.5rem', flexWrap: 'wrap', marginBottom: '1rem'}}>
   <span className="badge badge--primary">Informatique</span>
   <span className="badge badge--primary">Technologie</span>

--- a/site/docs/lets-steam/r1as02-breadboard.md
+++ b/site/docs/lets-steam/r1as02-breadboard.md
@@ -24,7 +24,7 @@ sidebar_position: 2
 
 :::info[Version STeaMi / MicroPython]
 
-Une version de cette activité portée sur la carte **STeaMi** en **MicroPython** est disponible dans le projet I-Novmicro : [Premier circuit sur breadboard](/ressources/inovmicro-exao/i02-premier-circuit-breadboard).
+Une version de cette activité portée sur la carte **STeaMi** en **MicroPython** est disponible dans le projet I-Novmicro : [Construire un premier circuit sur breadboard](/ressources/inovmicro-exao/i02-premier-circuit-breadboard).
 
 :::
 

--- a/site/docs/lets-steam/r1as04-capteur-lumiere.md
+++ b/site/docs/lets-steam/r1as04-capteur-lumiere.md
@@ -49,7 +49,7 @@ sidebar_position: 4
 
 :::info[Version STeaMi / MicroPython]
 
-Cette activité existe aussi adaptée pour la carte STeaMi en MicroPython : [Capteur de lumière (I-Novmicro)](/ressources/inovmicro-exao/i04-capteur-lumiere).
+Cette activité existe aussi adaptée pour la carte STeaMi en MicroPython : [Mesurer la lumière ambiante (I-Novmicro)](/ressources/inovmicro-exao/i04-capteur-lumiere).
 
 :::
 

--- a/site/docs/lets-steam/r1as09-accelerometre.md
+++ b/site/docs/lets-steam/r1as09-accelerometre.md
@@ -49,7 +49,7 @@ sidebar_position: 9
 
 :::info[Version STeaMi / MicroPython]
 
-Une version de cette activité portée sur la carte **STeaMi** en **MicroPython** est disponible dans le projet I-Novmicro : [Inclinaison avec accéléromètre](/ressources/inovmicro-exao/i09-inclinaison-accelerometre).
+Une version de cette activité portée sur la carte **STeaMi** en **MicroPython** est disponible dans le projet I-Novmicro : [Mesurer l'inclinaison avec l'accéléromètre](/ressources/inovmicro-exao/i09-inclinaison-accelerometre).
 
 :::
 

--- a/site/docs/lets-steam/r1as11-thermometre.md
+++ b/site/docs/lets-steam/r1as11-thermometre.md
@@ -46,7 +46,7 @@ sidebar_position: 11
 
 :::info[Version STeaMi / MicroPython]
 
-Une version de cette activité portée sur la carte **STeaMi** en **MicroPython** est disponible dans le projet I-Novmicro : [Thermomètre très lisible](/ressources/inovmicro-exao/i11-thermometre-lisible).
+Une version de cette activité portée sur la carte **STeaMi** en **MicroPython** est disponible dans le projet I-Novmicro : [Afficher un thermomètre très lisible](/ressources/inovmicro-exao/i11-thermometre-lisible).
 
 :::
 

--- a/site/docs/lets-steam/r1as12-detecteur-mouvement.md
+++ b/site/docs/lets-steam/r1as12-detecteur-mouvement.md
@@ -48,7 +48,7 @@ sidebar_position: 12
 
 :::info[Version STeaMi / MicroPython]
 
-Une version de cette activité portée sur la carte **STeaMi** en **MicroPython** est disponible dans le projet I-Novmicro : [Alarme de mouvement](/ressources/inovmicro-exao/i12-alarme-mouvement).
+Une version de cette activité portée sur la carte **STeaMi** en **MicroPython** est disponible dans le projet I-Novmicro : [Créer une alarme de mouvement](/ressources/inovmicro-exao/i12-alarme-mouvement).
 
 :::
 

--- a/site/docs/lets-steam/r1as14-minuteur.md
+++ b/site/docs/lets-steam/r1as14-minuteur.md
@@ -47,7 +47,7 @@ sidebar_position: 14
 
 :::info[Version STeaMi / MicroPython]
 
-Une version de cette activité portée sur la carte **STeaMi** en **MicroPython** est disponible dans le projet I-Novmicro : [Minuteur électronique](/ressources/inovmicro-exao/i14-minuteur-electronique).
+Une version de cette activité portée sur la carte **STeaMi** en **MicroPython** est disponible dans le projet I-Novmicro : [Fabriquer un minuteur électronique](/ressources/inovmicro-exao/i14-minuteur-electronique).
 
 :::
 


### PR DESCRIPTION
## Résumé

Renomme les fiches pour un **titre commençant par un verbe**, sans toucher aux URLs ni à la navigation. Validation **projet par projet** ; ce lot couvre **I-Novmicro**.

### Lot 1 — I-Novmicro (12 fiches)

- Dépannage STeaMi → **Dépanner la STeaMi**
- Premier circuit sur breadboard → **Construire un premier circuit sur breadboard**
- Capteur de lumière avec la STeaMi → **Mesurer la lumière ambiante**
- Envoyer des messages en code Morse avec la STeaMi → **Envoyer des messages en code Morse**
- Inclinaison avec accéléromètre → **Mesurer l'inclinaison avec l'accéléromètre**
- Thermomètre très lisible → **Afficher un thermomètre très lisible**
- Alarme de mouvement → **Créer une alarme de mouvement**
- Minuteur électronique → **Fabriquer un minuteur électronique**
- Thonny / VS Code / Vittascience / Bases du langage → **Prendre en main MicroPython avec Thonny / avec VS Code / la STeaMi sur l'éditeur Vittascience / Découvrir les bases de MicroPython**

Chaque renommage met à jour `title` + H1 + `sidebar_label`. **41 textes de liens** citant l'ancien titre ont été corrigés (cibles inchangées).

## Périmètre / sécurité

- Aucun changement d'URL/slug.
- Aucune cible de lien modifiée (uniquement le texte affiché).
- Navigation, fil d'Ariane, recherche : inchangés.

Refs #239

## Test plan

- [ ] `npm run site:build` vert (CI)
- [ ] Vérifier les titres + sidebar I-Novmicro et quelques liens (ex. depuis i01-led vers Thonny)

🤖 Generated with [Claude Code](https://claude.com/claude-code)