### PR TITLE
fix(css): trait du hero plus court, centré et plus épais

### DIFF
--- a/site/src/css/custom.css
+++ b/site/src/css/custom.css
@@ -338,9 +338,9 @@ article > table:first-of-type {
 .wikilab-hero__title::after {
   content: '';
   display: block;
-  width: calc(100% + 3rem);
-  height: 1px;
-  margin: 1rem 0 0 -1.5rem;
+  width: 100px;
+  height: 2px;
+  margin: 0.4rem auto 0;
   background: rgba(255, 255, 255, 0.85);
 }
 


### PR DESCRIPTION
## Résumé

Ajuste le trait décoratif sous « WIKI@LAB » (accueil) : court (100 px) et **centré** au lieu de déborder, **2 px** (un peu plus épais), écart réduit à **0,4 rem** du titre.

Validé visuellement en local.

Closes #241

## Test plan

- [ ] `npm run site:build` vert (CI)
- [ ] Vérifier le hero d'accueil

🤖 Generated with [Claude Code](https://claude.com/claude-code)