### PR TITLE
docs(magnetics): titres verbe-en-tête (Lot 4)

### DIFF
--- a/site/docs/magnetics/makecode-stm32.md
+++ b/site/docs/magnetics/makecode-stm32.md
@@ -1,7 +1,7 @@
 ---
 id: makecode-stm32
-title: Magnetics — Créer des projets multicartes (MakeCode STM32)
-sidebar_label: 'Magnetics — MakeCode STM32'
+title: Créer des projets multicartes sur MakeCode (STM32)
+sidebar_label: 'MakeCode STM32'
 sidebar_position: 2
 ---
 
@@ -9,7 +9,7 @@ sidebar_position: 2
 
 <div style={{flex: 1}}>
 
-# Magnetics — Créer des projets multicartes (MakeCode STM32)
+# Créer des projets multicartes sur MakeCode (STM32)
 
 <div style={{display: 'flex', gap: '0.5rem', flexWrap: 'wrap', marginBottom: '1rem'}}>
   <span className="badge badge--primary">Informatique</span>

--- a/site/docs/magnetics/microbit.md
+++ b/site/docs/magnetics/microbit.md
@@ -1,7 +1,7 @@
 ---
 id: microbit
-title: Magnetics — Créer des projets multicartes (micro:bit)
-sidebar_label: 'Magnetics — micro:bit'
+title: Créer des projets multicartes sur micro:bit
+sidebar_label: 'micro:bit'
 sidebar_position: 1
 ---
 
@@ -9,7 +9,7 @@ sidebar_position: 1
 
 <div style={{flex: 1}}>
 
-# Magnetics — Créer des projets multicartes (micro:bit)
+# Créer des projets multicartes sur micro:bit
 
 <div style={{display: 'flex', gap: '0.5rem', flexWrap: 'wrap', marginBottom: '1rem'}}>
   <span className="badge badge--primary">Informatique</span>

--- a/site/docs/magnetics/micropython.md
+++ b/site/docs/magnetics/micropython.md
@@ -1,7 +1,7 @@
 ---
 id: micropython
-title: Magnetics — Créer des projets multicartes (MicroPython)
-sidebar_label: 'Magnetics — MicroPython'
+title: Créer des projets multicartes en MicroPython
+sidebar_label: 'MicroPython'
 sidebar_position: 3
 ---
 
@@ -9,7 +9,7 @@ sidebar_position: 3
 
 <div style={{flex: 1}}>
 
-# Magnetics — Créer des projets multicartes (MicroPython)
+# Créer des projets multicartes en MicroPython
 
 <div style={{display: 'flex', gap: '0.5rem', flexWrap: 'wrap', marginBottom: '1rem'}}>
   <span className="badge badge--primary">Informatique</span>


### PR DESCRIPTION
## Résumé
Lot 4 — Magnetics. Retire le préfixe « Magnetics — » et l'em-dash ; titres verbe-en-tête (title + H1) et sidebar_label raccourci.

| Actuel | Nouveau (titre) | sidebar_label |
|---|---|---|
| Magnetics — Créer des projets multicartes (MakeCode STM32) | Créer des projets multicartes sur MakeCode (STM32) | MakeCode STM32 |
| Magnetics — Créer des projets multicartes (micro:bit) | Créer des projets multicartes sur micro:bit | micro:bit |
| Magnetics — Créer des projets multicartes (MicroPython) | Créer des projets multicartes en MicroPython | MicroPython |

## Périmètre / sécurité
- Aucun changement d'URL/slug.
- Aucune cible de lien modifiée.
- Navigation, fil d'Ariane, recherche : inchangés.

Refs #239