### PR TITLE
docs(inovmicro-exao): titres verbe-en-tête (Lot 1)

### DIFF
--- a/site/docs/inovmicro-exao/depannage.md
+++ b/site/docs/inovmicro-exao/depannage.md
@@ -1,13 +1,13 @@
 ---
 id: depannage
-title: Dépannage STeaMi
-sidebar_label: 'Dépannage'
+title: Dépanner la STeaMi
+sidebar_label: 'Dépanner'
 ---
 
 <div style={{display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: '2rem', marginBottom: '1.5rem'}}>
 <div style={{flex: 1}}>
 
-# Dépannage STeaMi
+# Dépanner la STeaMi
 
 <div style={{display: 'flex', gap: '0.5rem', flexWrap: 'wrap', marginBottom: '1rem'}}>
   <span className="badge badge--primary">Informatique</span>

--- a/site/docs/inovmicro-exao/i02-premier-circuit-breadboard.md
+++ b/site/docs/inovmicro-exao/i02-premier-circuit-breadboard.md
@@ -1,14 +1,14 @@
 ---
 id: i02-premier-circuit-breadboard
-title: Premier circuit sur breadboard
-sidebar_label: "Premier circuit sur breadboard"
+title: Construire un premier circuit sur breadboard
+sidebar_label: "Construire un premier circuit sur breadboard"
 sidebar_position: 2
 ---
 
 <div style={{display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: '2rem', marginBottom: '1.5rem'}}>
 <div style={{flex: 1}}>
 
-# Premier circuit sur breadboard
+# Construire un premier circuit sur breadboard
 
 <div style={{display: 'flex', gap: '0.5rem', flexWrap: 'wrap', marginBottom: '1rem'}}>
   <span className="badge badge--primary">Informatique</span>

--- a/site/docs/inovmicro-exao/i04-capteur-lumiere.md
+++ b/site/docs/inovmicro-exao/i04-capteur-lumiere.md
@@ -1,13 +1,13 @@
 ---
 id: i04-capteur-lumiere
-title: Capteur de lumière avec la STeaMi
-sidebar_label: "Capteur de lumière"
+title: Mesurer la lumière ambiante
+sidebar_label: "Mesurer la lumière"
 sidebar_position: 11
 ---
 
 <div style={{display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: '2rem', marginBottom: '1.5rem'}}>
 <div style={{flex: 1}}>
-# Capteur de lumière avec la STeaMi
+# Mesurer la lumière ambiante
 
 <div style={{display: 'flex', gap: '0.5rem', flexWrap: 'wrap', marginBottom: '1rem'}}>
   <span className="badge badge--primary">Informatique</span>

--- a/site/docs/inovmicro-exao/i06-code-morse.md
+++ b/site/docs/inovmicro-exao/i06-code-morse.md
@@ -1,13 +1,13 @@
 ---
 id: i06-code-morse
-title: Envoyer des messages en code Morse avec la STeaMi
+title: Envoyer des messages en code Morse
 sidebar_label: "Code Morse"
 sidebar_position: 13
 ---
 
 <div style={{display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: '2rem', marginBottom: '1.5rem'}}>
 <div style={{flex: 1}}>
-# Envoyer des messages en code Morse avec la STeaMi
+# Envoyer des messages en code Morse
 
 <div style={{display: 'flex', gap: '0.5rem', flexWrap: 'wrap', marginBottom: '1rem'}}>
   <span className="badge badge--primary">Informatique</span>

--- a/site/docs/inovmicro-exao/i09-inclinaison-accelerometre.md
+++ b/site/docs/inovmicro-exao/i09-inclinaison-accelerometre.md
@@ -1,13 +1,13 @@
 ---
 id: i09-inclinaison-accelerometre
-title: Inclinaison avec accéléromètre
-sidebar_label: "Inclinaison avec accéléromètre"
+title: Mesurer l'inclinaison avec l'accéléromètre
+sidebar_label: "Mesurer l'inclinaison avec l'accéléromètre"
 sidebar_position: 9
 ---
 
 <div style={{display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: '2rem', marginBottom: '1.5rem'}}>
 <div style={{flex: 1}}>
-# Inclinaison avec accéléromètre
+# Mesurer l'inclinaison avec l'accéléromètre
 
 <div style={{display: 'flex', gap: '0.5rem', flexWrap: 'wrap', marginBottom: '1rem'}}>
   <span className="badge badge--primary">Informatique</span>

--- a/site/docs/inovmicro-exao/i11-thermometre-lisible.md
+++ b/site/docs/inovmicro-exao/i11-thermometre-lisible.md
@@ -1,13 +1,13 @@
 ---
 id: i11-thermometre-lisible
-title: Thermomètre très lisible
-sidebar_label: "Thermomètre très lisible"
+title: Afficher un thermomètre très lisible
+sidebar_label: "Afficher un thermomètre très lisible"
 sidebar_position: 11
 ---
 
 <div style={{display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: '2rem', marginBottom: '1.5rem'}}>
 <div style={{flex: 1}}>
-# Thermomètre très lisible
+# Afficher un thermomètre très lisible
 
 <div style={{display: 'flex', gap: '0.5rem', flexWrap: 'wrap', marginBottom: '1rem'}}>
   <span className="badge badge--primary">Informatique</span>

--- a/site/docs/inovmicro-exao/i12-alarme-mouvement.md
+++ b/site/docs/inovmicro-exao/i12-alarme-mouvement.md
@@ -1,7 +1,7 @@
 ---
 id: i12-alarme-mouvement
-title: Alarme de mouvement
-sidebar_label: 'Alarme de mouvement'
+title: Créer une alarme de mouvement
+sidebar_label: 'Créer une alarme de mouvement'
 sidebar_position: 12
 ---
 
@@ -9,7 +9,7 @@ sidebar_position: 12
 
 <div style={{flex: 1}}>
 
-# Alarme de mouvement
+# Créer une alarme de mouvement
 
 <div style={{display: 'flex', gap: '0.5rem', flexWrap: 'wrap', marginBottom: '1rem'}}>
   <span className="badge badge--primary">Informatique</span>

--- a/site/docs/inovmicro-exao/i14-minuteur-electronique.md
+++ b/site/docs/inovmicro-exao/i14-minuteur-electronique.md
@@ -1,13 +1,13 @@
 ---
 id: i14-minuteur-electronique
-title: Minuteur électronique
-sidebar_label: "Minuteur électronique"
+title: Fabriquer un minuteur électronique
+sidebar_label: "Fabriquer un minuteur électronique"
 sidebar_position: 14
 ---
 
 <div style={{display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: '2rem', marginBottom: '1.5rem'}}>
 <div style={{flex: 1}}>
-# Minuteur électronique
+# Fabriquer un minuteur électronique
 
 <div style={{display: 'flex', gap: '0.5rem', flexWrap: 'wrap', marginBottom: '1rem'}}>
   <span className="badge badge--primary">Informatique</span>

--- a/site/docs/inovmicro-exao/t03-decouverte-thonny.md
+++ b/site/docs/inovmicro-exao/t03-decouverte-thonny.md
@@ -1,13 +1,13 @@
 ---
 id: t03-decouverte-thonny
-title: "Thonny : Prise en main de MicroPython sur la STeaMi"
+title: "Prendre en main MicroPython avec Thonny"
 sidebar_label: "Thonny"
 sidebar_position: 3
 ---
 
 <div style={{display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: '2rem', marginBottom: '1.5rem'}}>
 <div style={{flex: 1}}>
-# Thonny : Prise en main de MicroPython sur la STeaMi
+# Prendre en main MicroPython avec Thonny
 <div style={{display: 'flex', gap: '0.5rem', flexWrap: 'wrap', marginBottom: '1rem'}}>
   <span className="badge badge--primary">Informatique</span>
   <span className="badge badge--primary">Technologie</span>

--- a/site/docs/inovmicro-exao/t04-vscode.md
+++ b/site/docs/inovmicro-exao/t04-vscode.md
@@ -1,13 +1,13 @@
 ---
 id: t04-vscode
-title: "VS Code : Prise en main de MicroPython sur la STeaMi"
+title: "Prendre en main MicroPython avec VS Code"
 sidebar_label: "VS Code"
 sidebar_position: 4
 ---
 
 <div style={{display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: '2rem', marginBottom: '1.5rem'}}>
 <div style={{flex: 1}}>
-# VS Code : Prise en main de MicroPython sur la STeaMi
+# Prendre en main MicroPython avec VS Code
 <div style={{display: 'flex', gap: '0.5rem', flexWrap: 'wrap', marginBottom: '1rem'}}>
   <span className="badge badge--primary">Informatique</span>
   <span className="badge badge--primary">Technologie</span>

--- a/site/docs/inovmicro-exao/t05-vittascience.md
+++ b/site/docs/inovmicro-exao/t05-vittascience.md
@@ -1,6 +1,6 @@
 ---
 id: t05-vittascience
-title: "Vittascience : Prise en main de MicroPython et blocs sur la STeaMi"
+title: "Prendre en main la STeaMi sur l'éditeur Vittascience"
 sidebar_label: "Vittascience"
 sidebar_position: 5
 ---
@@ -8,7 +8,7 @@ sidebar_position: 5
 <div style={{display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: '2rem', marginBottom: '1.5rem'}}>
 <div style={{flex: 1}}>
 
-# Vittascience : Prise en main de MicroPython et blocs sur la STeaMi
+# Prendre en main la STeaMi sur l'éditeur Vittascience
 
 <div style={{display: 'flex', gap: '0.5rem', flexWrap: 'wrap', marginBottom: '1rem'}}>
   <span className="badge badge--primary">Informatique</span>

--- a/site/docs/inovmicro-exao/t06-bases-micropython.md
+++ b/site/docs/inovmicro-exao/t06-bases-micropython.md
@@ -1,13 +1,13 @@
 ---
 id: t06-bases-micropython
-title: "Bases du langage : Prise en main de MicroPython"
+title: "Découvrir les bases de MicroPython"
 sidebar_label: "Bases du langage"
 sidebar_position: 6
 ---
 
 <div style={{display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: '2rem', marginBottom: '1.5rem'}}>
 <div style={{flex: 1}}>
-# Bases du langage : Prise en main de MicroPython
+# Découvrir les bases de MicroPython
 <div style={{display: 'flex', gap: '0.5rem', flexWrap: 'wrap', marginBottom: '1rem'}}>
   <span className="badge badge--primary">Informatique</span>
   <span className="badge badge--primary">Technologie</span>


### PR DESCRIPTION
## Résumé
Lot 1 — I-Novmicro. Titres reformulés en verbe-en-tête (title + H1 + sidebar_label). Refait proprement sur `main` à jour (remplace #240, qui était en conflit).

| Actuel | Nouveau |
|---|---|
| Dépannage STeaMi | Dépanner la STeaMi |
| Premier circuit sur breadboard | Construire un premier circuit sur breadboard |
| Capteur de lumière avec la STeaMi | Mesurer la lumière ambiante |
| Envoyer des messages en code Morse avec la STeaMi | Envoyer des messages en code Morse |
| Inclinaison avec accéléromètre | Mesurer l'inclinaison avec l'accéléromètre |
| Thermomètre très lisible | Afficher un thermomètre très lisible |
| Alarme de mouvement | Créer une alarme de mouvement |
| Minuteur électronique | Fabriquer un minuteur électronique |
| Thonny : Prise en main de MicroPython sur la STeaMi | Prendre en main MicroPython avec Thonny |
| VS Code : Prise en main de MicroPython sur la STeaMi | Prendre en main MicroPython avec VS Code |
| Vittascience : Prise en main de MicroPython et blocs sur la STeaMi | Prendre en main la STeaMi sur l'éditeur Vittascience |
| Bases du langage : Prise en main de MicroPython | Découvrir les bases de MicroPython |

Déjà verbe-en-tête (conservés) : Découvrir la carte STeaMi, Faire clignoter une LED, Utiliser des boutons-poussoirs, Contrôler avec un potentiomètre, Composer une mélodie, Fabriquer un thérémine, Afficher du texte sur l'écran OLED, Animer avec un servomoteur, Collecter des données avec la STeaMi.

## Périmètre / sécurité
- Aucun changement d'URL/slug.
- Aucune cible de lien modifiée.
- Navigation, fil d'Ariane, recherche : inchangés.

Refs #239