### PR TITLE
fix(sidebar): « : » au lieu de l'em-dash dans les libellés de section

### DIFF
--- a/site/sidebars.ts
+++ b/site/sidebars.ts
@@ -21,7 +21,7 @@ const PROJECT_ORDER: Project[] = [
 
 // Construit les sections de la sidebar à partir des fiches groupées
 // par projet. Le label de chaque section est de la forme :
-//   "Nom du projet — Sous-titre verbe-début"
+//   "Nom du projet : Sous-titre verbe-début"
 // (cf. champ `subtitle` dans projects.ts). Cela donne du contexte
 // d'entrée au lecteur quand il navigue d'un projet à l'autre.
 //
@@ -42,7 +42,7 @@ const projectSections = PROJECT_ORDER.map((proj) => {
   const info = projectsInfo[proj];
   return {
     type: 'category' as const,
-    label: `${info.name} — ${info.subtitle}`,
+    label: `${info.name} : ${info.subtitle}`,
     collapsed: true,
     items,
   };


### PR DESCRIPTION
## Résumé
Les libellés de section de la sidebar passent de `Projet — Sous-titre` à `Projet : Sous-titre` (une ligne dans `site/sidebars.ts`, + commentaire mis à jour). Concerne les 11 sections de projet.

Avant → après (exemples) :
- `Let's STEAM — Programmer la STM32 sur MakeCode` → `Let's STEAM : Programmer la STM32 sur MakeCode`
- `Magnetics — Connecter des cartes en BLE Mesh` → `Magnetics : Connecter des cartes en BLE Mesh`

## Périmètre / sécurité
- Aucun changement d'URL/slug.
- Aucune cible de lien modifiée.
- Navigation, fil d'Ariane, recherche : inchangés (seul le texte du libellé de section change).

Closes #254