### PR TITLE
fix(inovmicro-exao): sidebar_label = titre complet

### DIFF
--- a/site/docs/inovmicro-exao/depannage.md
+++ b/site/docs/inovmicro-exao/depannage.md
@@ -1,7 +1,7 @@
 ---
 id: depannage
 title: Dépanner la STeaMi
-sidebar_label: 'Dépanner'
+sidebar_label: "Dépanner la STeaMi"
 ---
 
 <div style={{display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: '2rem', marginBottom: '1.5rem'}}>

--- a/site/docs/inovmicro-exao/i04-capteur-lumiere.md
+++ b/site/docs/inovmicro-exao/i04-capteur-lumiere.md
@@ -1,7 +1,7 @@
 ---
 id: i04-capteur-lumiere
 title: Mesurer la lumière ambiante
-sidebar_label: "Mesurer la lumière"
+sidebar_label: "Mesurer la lumière ambiante"
 sidebar_position: 11
 ---
 

--- a/site/docs/inovmicro-exao/i06-code-morse.md
+++ b/site/docs/inovmicro-exao/i06-code-morse.md
@@ -1,7 +1,7 @@
 ---
 id: i06-code-morse
 title: Envoyer des messages en code Morse
-sidebar_label: "Code Morse"
+sidebar_label: "Envoyer des messages en code Morse"
 sidebar_position: 13
 ---
 

--- a/site/docs/inovmicro-exao/i10-texte-oled.md
+++ b/site/docs/inovmicro-exao/i10-texte-oled.md
@@ -1,7 +1,7 @@
 ---
 id: i10-texte-oled
 title: Afficher du texte sur l'écran OLED
-sidebar_label: "Écran OLED"
+sidebar_label: "Afficher du texte sur l'écran OLED"
 sidebar_position: 17
 ---
 

--- a/site/docs/inovmicro-exao/i15-collecter-donnees.md
+++ b/site/docs/inovmicro-exao/i15-collecter-donnees.md
@@ -1,7 +1,7 @@
 ---
 id: i15-collecter-donnees
 title: Collecter des données avec la STeaMi
-sidebar_label: "Collecter des données"
+sidebar_label: "Collecter des données avec la STeaMi"
 sidebar_position: 15
 ---
 

--- a/site/docs/inovmicro-exao/t03-decouverte-thonny.md
+++ b/site/docs/inovmicro-exao/t03-decouverte-thonny.md
@@ -1,7 +1,7 @@
 ---
 id: t03-decouverte-thonny
 title: "Prendre en main MicroPython avec Thonny"
-sidebar_label: "Thonny"
+sidebar_label: "Prendre en main MicroPython avec Thonny"
 sidebar_position: 3
 ---
 

--- a/site/docs/inovmicro-exao/t04-vscode.md
+++ b/site/docs/inovmicro-exao/t04-vscode.md
@@ -1,7 +1,7 @@
 ---
 id: t04-vscode
 title: "Prendre en main MicroPython avec VS Code"
-sidebar_label: "VS Code"
+sidebar_label: "Prendre en main MicroPython avec VS Code"
 sidebar_position: 4
 ---
 

--- a/site/docs/inovmicro-exao/t05-vittascience.md
+++ b/site/docs/inovmicro-exao/t05-vittascience.md
@@ -1,7 +1,7 @@
 ---
 id: t05-vittascience
 title: "Prendre en main la STeaMi sur l'éditeur Vittascience"
-sidebar_label: "Vittascience"
+sidebar_label: "Prendre en main la STeaMi sur l'éditeur Vittascience"
 sidebar_position: 5
 ---
 

--- a/site/docs/inovmicro-exao/t06-bases-micropython.md
+++ b/site/docs/inovmicro-exao/t06-bases-micropython.md
@@ -1,7 +1,7 @@
 ---
 id: t06-bases-micropython
 title: "Découvrir les bases de MicroPython"
-sidebar_label: "Bases du langage"
+sidebar_label: "Découvrir les bases de MicroPython"
 sidebar_position: 6
 ---
 


### PR DESCRIPTION
## Résumé
9 fiches I-Novmicro gardaient un `sidebar_label` **court** alors que la convention (appliquée à tous les autres projets) est `sidebar_label` = titre complet verbe-en-tête. On aligne :

| Fiche | Label avant | Label après |
|-------|-------------|-------------|
| depannage | Dépanner | Dépanner la STeaMi |
| i04-capteur-lumiere | Mesurer la lumière | Mesurer la lumière ambiante |
| i06-code-morse | Code Morse | Envoyer des messages en code Morse |
| i10-texte-oled | Écran OLED | Afficher du texte sur l'écran OLED |
| i15-collecter-donnees | Collecter des données | Collecter des données avec la STeaMi |
| t03-decouverte-thonny | Thonny | Prendre en main MicroPython avec Thonny |
| t04-vscode | VS Code | Prendre en main MicroPython avec VS Code |
| t05-vittascience | Vittascience | Prendre en main la STeaMi sur l'éditeur Vittascience |
| t06-bases-micropython | Bases du langage | Découvrir les bases de MicroPython |

## Périmètre / sécurité
- Seul `sidebar_label` change (titre de page et H1 déjà à jour).
- Aucun changement d'URL/slug, aucune cible de lien, navigation inchangée.

Closes #262